### PR TITLE
[FEATURE/#3] 세션기반 회원가입, 로그인, 로그아웃 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,9 @@ dependencies {
 
 	// Security & JWT
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+//	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+//	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+//	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
 	// JPA & PostgreSQL
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -48,6 +48,7 @@ dependencies {
 
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'

--- a/src/main/java/com/timiroom/config/RedisConfig.java
+++ b/src/main/java/com/timiroom/config/RedisConfig.java
@@ -1,0 +1,16 @@
+package com.timiroom.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisSerializer<Object> springSessionDefaultRedisSerializer() {
+        return new GenericJackson2JsonRedisSerializer();
+    }
+}

--- a/src/main/java/com/timiroom/config/SecurityConfig.java
+++ b/src/main/java/com/timiroom/config/SecurityConfig.java
@@ -1,0 +1,56 @@
+package com.timiroom.config;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.savedrequest.NullRequestCache;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .requestCache(cache -> cache.requestCache(new NullRequestCache()))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .logout(logout -> logout
+                        .logoutUrl("/auth/logout")
+                        .invalidateHttpSession(true)
+                        .deleteCookies("SESSION")
+
+                        .logoutSuccessHandler((request, response, authentication) -> {
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.setStatus(HttpServletResponse.SC_OK);
+                            response.getWriter().write("{\"message\": \"로그아웃 성공\"}");
+                        })
+                )
+                .sessionManagement(session -> session
+                        .maximumSessions(1)
+                        .maxSessionsPreventsLogin(false)
+                );;;
+        return http.build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager(AuthenticationConfiguration config)
+            throws Exception{
+        return config.getAuthenticationManager();
+    }
+
+}

--- a/src/main/java/com/timiroom/domain/member/Member.java
+++ b/src/main/java/com/timiroom/domain/member/Member.java
@@ -1,0 +1,39 @@
+package com.timiroom.domain.member;
+
+import com.timiroom.global.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "member_name", nullable = false, unique = true)
+    private String memberName;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    public static Member create(String memberName, String password, String email){
+        Member member = new Member();
+        member.memberName = memberName;
+        member.password = password;
+        member.email = email;
+        member.role = Role.USER;
+        return member;
+    }
+}

--- a/src/main/java/com/timiroom/domain/member/MemberController.java
+++ b/src/main/java/com/timiroom/domain/member/MemberController.java
@@ -1,0 +1,25 @@
+package com.timiroom.domain.member;
+
+import com.timiroom.domain.member.dto.MemberLoginRequest;
+import com.timiroom.domain.member.dto.MemberRegisterRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/register")
+    public void register(@RequestBody MemberRegisterRequest request){
+        memberService.register(request);
+    }
+
+    @PostMapping("/login")
+    public void sessionLogin(@RequestBody MemberLoginRequest request, HttpSession session){
+        memberService.login(request, session);
+    }
+}

--- a/src/main/java/com/timiroom/domain/member/MemberRepository.java
+++ b/src/main/java/com/timiroom/domain/member/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.timiroom.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findAllByMemberName(String memberName);
+}

--- a/src/main/java/com/timiroom/domain/member/MemberService.java
+++ b/src/main/java/com/timiroom/domain/member/MemberService.java
@@ -1,0 +1,39 @@
+package com.timiroom.domain.member;
+
+import com.timiroom.domain.member.dto.MemberLoginRequest;
+import com.timiroom.domain.member.dto.MemberRegisterRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManager authenticationManager;
+
+    public void register(MemberRegisterRequest request){
+
+        var hash = passwordEncoder.encode(request.getPassword());
+
+        Member member = Member.create(request.getMemberName(), hash, request.getEmail());
+
+        memberRepository.save(member);
+    }
+
+    public void login(MemberLoginRequest request, HttpSession session){
+
+        var token = new UsernamePasswordAuthenticationToken(request.getMemberName(), request.getPassword());
+
+        Authentication authentication = authenticationManager.authenticate(token);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/timiroom/domain/member/Role.java
+++ b/src/main/java/com/timiroom/domain/member/Role.java
@@ -1,0 +1,5 @@
+package com.timiroom.domain.member;
+
+public enum Role {
+    USER, ADMIN;
+}

--- a/src/main/java/com/timiroom/domain/member/dto/MemberLoginRequest.java
+++ b/src/main/java/com/timiroom/domain/member/dto/MemberLoginRequest.java
@@ -1,0 +1,9 @@
+package com.timiroom.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberLoginRequest {
+    private String memberName;
+    private String password;
+}

--- a/src/main/java/com/timiroom/domain/member/dto/MemberRegisterRequest.java
+++ b/src/main/java/com/timiroom/domain/member/dto/MemberRegisterRequest.java
@@ -1,0 +1,10 @@
+package com.timiroom.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberRegisterRequest {
+    private String memberName;
+    private String password;
+    private String email;
+}

--- a/src/main/java/com/timiroom/global/BaseEntity.java
+++ b/src/main/java/com/timiroom/global/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.timiroom.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Column
+    private LocalDateTime deletedAt;  // 소프트 딜리트용 (수동 처리)
+}

--- a/src/main/java/com/timiroom/global/MemberDetailService.java
+++ b/src/main/java/com/timiroom/global/MemberDetailService.java
@@ -1,0 +1,30 @@
+package com.timiroom.global;
+
+import com.timiroom.domain.member.Member;
+import com.timiroom.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberDetailService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String memberName) throws UsernameNotFoundException{
+        Member member = memberRepository.findAllByMemberName(memberName)
+                .orElseThrow(() -> new UsernameNotFoundException("이름을 찾을 수 없습니다."));
+
+        return User.builder()
+                .username(member.getMemberName())
+                .password(member.getPassword())
+                .roles(member.getRole().name())
+                .build();
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,3 +15,6 @@ spring:
     redis:
       host: localhost
       port: 6379
+
+    session:
+      timeout: 30m  # 세션 만료 시간


### PR DESCRIPTION
## 관련 이슈
Closes #3 

## 작업 내용

### 회원가입
- `Member` 엔티티 생성
- `BaseEntity` 상속으로 `createdAt`, `updatedAt`, `deletedAt` 자동 관리
- `Role` Enum 분리 (`USER`, `ADMIN`)
- `Member.create()` 팩토리 메서드로 생성 시 기본 `Role.USER` 부여
- 비밀번호 BCrypt 암호화 저장

### 로그인
- `MemberDetailService` - `UserDetailsService` 구현체
- `AuthenticationManager`로 인증 처리
- 인증 성공 시 세션 생성 → Redis 저장
- 클라이언트에 SESSION 쿠키 반환

### 로그아웃
- Security `logoutUrl` 설정으로 처리
- 세션 삭제 + SESSION 쿠키 삭제
- `logoutSuccessHandler`로 200 응답 반환

## 테스트
- [o] 회원가입 성공
- [o] 로그인 성공
- [o] 로그아웃 성공 후 세션 삭제 확인
