### PR TITLE
[CHORE/#6] rag-pipeline 배포 설정 추가

### DIFF
--- a/.github/workflows/deploy-rag.yml
+++ b/.github/workflows/deploy-rag.yml
@@ -1,0 +1,66 @@
+name: Rag-Pipeline CI/CD
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'rag-pipeline/**'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Image Tag
+        run: echo "IMAGE_TAG=sha-${{ github.sha }}" >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v4
+        with:
+          context: rag-pipeline
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/timiroom-rag-pipeline:${{ env.IMAGE_TAG }}
+
+      - name: Setup Kustomize
+        uses: imranismail/setup-kustomize@v2
+
+      - name: Install kubeseal
+        run: |
+          wget https://github.com/bitnami-labs/sealed-secrets/releases/download/v0.27.3/kubeseal-0.27.3-linux-amd64.tar.gz
+          tar -xvzf kubeseal-0.27.3-linux-amd64.tar.gz kubeseal
+          sudo mv kubeseal /usr/local/bin/
+
+      - name: Update Ops Repo with Sealed Secrets
+        run: |
+          git clone https://${{ secrets.GH_PAT }}@github.com/timiroom/timiroom-ops.git
+          cd timiroom-ops/apps/rag-pipeline
+
+          if [ ! -f pub-cert.pem ]; then
+            echo "❌ ERROR: pub-cert.pem not found in timiroom-ops/apps/rag-pipeline/"
+            exit 1
+          fi
+
+          kustomize edit set image rag-pipeline-image=${{ secrets.DOCKER_USERNAME }}/timiroom-rag-pipeline:${{ env.IMAGE_TAG }}
+
+          rm -f temp-secrets.env
+          echo "$ALL_SECRETS_JSON" | jq -r 'to_entries[] | select(.key | startswith("RAG_")) | "\(.key | sub("^RAG_"; ""))=\(.value)"' > temp-secrets.env
+
+          kubectl create secret generic rag-pipeline-secrets --from-env-file=temp-secrets.env --dry-run=client -o yaml > plain-secret.yaml
+          kubeseal --format=yaml --cert=pub-cert.pem < plain-secret.yaml > sealed-secret.yaml
+          rm -f temp-secrets.env plain-secret.yaml
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add kustomization.yaml sealed-secret.yaml
+          git commit -m "chore: deploy rag-pipeline image [${{ env.IMAGE_TAG }}]"
+          git push
+        env:
+          ALL_SECRETS_JSON: ${{ toJson(secrets) }}

--- a/rag-pipeline/Dockerfile
+++ b/rag-pipeline/Dockerfile
@@ -1,0 +1,29 @@
+# Multi-stage build for RAG Pipeline
+FROM gradle:8.8-jdk21 AS builder
+
+WORKDIR /app
+
+COPY build.gradle settings.gradle gradle.properties* ./
+COPY gradle ./gradle
+COPY src ./src
+
+RUN gradle build -x test --no-daemon
+
+# Production stage
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+ENV SPRING_PROFILES_ACTIVE=prod
+ENV JAVA_OPTS="-Xmx1536m -Xms512m"
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+RUN addgroup -g 1000 spring && \
+    adduser -u 1000 -G spring -s /bin/sh -D spring
+
+USER spring
+
+EXPOSE 8080
+
+CMD ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
## 작업 내용
- `rag-pipeline/Dockerfile` 추가 (멀티스테이지 빌드, JVM 힙 1536m)
- `.github/workflows/deploy-rag.yml` 추가 (main 브랜치 push 시 자동 배포)

## 변경 이유
rag-pipeline(AI 기능 전체)이 별도 Spring Boot 앱임에도 Dockerfile과 CD 파이프라인이 없어 배포 불가 상태였음.
메인 백엔드(`deploy.yml`)와 동일한 패턴으로 구성:
- Docker Hub 이미지 빌드/푸시 (`chunwol/timiroom-rag-pipeline`)
- timiroom-ops `apps/rag-pipeline/` 이미지 태그 자동 업데이트
- `RAG_` prefix 시크릿으로 Sealed Secret 생성

## 테스트 방법
- `rag-pipeline/` 변경 후 main 머지 시 워크플로우 트리거 확인
- GitHub Secrets에 `RAG_OPENAI_API_KEY`, `RAG_ANTHROPIC_API_KEY`, `RAG_COHERE_API_KEY`, `RAG_DB_USERNAME`, `RAG_DB_PASSWORD` 등록 필요

## 관련 이슈
Closes #6