### PR TITLE
[CHORE/#6] CORS 다중 도메인 설정 및 RAG pipeline 프로덕션 설정 (#6)

### DIFF
--- a/rag-pipeline/src/main/java/com/rag/pipeline/common/config/CorsConfig.java
+++ b/rag-pipeline/src/main/java/com/rag/pipeline/common/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package com.rag.pipeline.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,14 +8,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-            .allowedOrigins(
-                "http://localhost:3000",
-                "http://localhost:5500",   // VSCode Live Server
-                "http://127.0.0.1:5500"
-            )
+            .allowedOrigins(allowedOrigins.split(","))
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .exposedHeaders("Content-Type", "Cache-Control", "Transfer-Encoding", "X-Accel-Buffering")

--- a/rag-pipeline/src/main/resources/application-prod.yml
+++ b/rag-pipeline/src/main/resources/application-prod.yml
@@ -2,6 +2,9 @@
 # 민감 정보는 환경변수로 관리합니다.
 # 필요 환경변수: DB_URL, DB_USERNAME, DB_PASSWORD, KAFKA_BOOTSTRAP_SERVERS
 
+cors:
+  allowed-origins: "https://timiroom.kro.kr"
+
 spring:
   jpa:
     hibernate:

--- a/rag-pipeline/src/main/resources/application.yml
+++ b/rag-pipeline/src/main/resources/application.yml
@@ -85,6 +85,9 @@ spring:
         "[spring.json.trusted.packages]": "com.rag.pipeline.*"
 
 
+cors:
+  allowed-origins: "http://localhost:3000,http://localhost:5500,http://127.0.0.1:5500"
+
 # ── 서버 설정 ────────────────────────────────────────────────────
 server:
   servlet:

--- a/src/main/java/com/timiroom/config/SecurityConfig.java
+++ b/src/main/java/com/timiroom/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.timiroom.domain.oauth.OAuth2MemberService;
 import com.timiroom.domain.oauth.OAuth2SuccessHandler;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -16,12 +17,18 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final OAuth2MemberService oAuth2MemberService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -65,7 +72,7 @@ public class SecurityConfig {
     @Bean
     public org.springframework.web.cors.CorsConfigurationSource corsConfigurationSource() {
         org.springframework.web.cors.CorsConfiguration configuration = new org.springframework.web.cors.CorsConfiguration();
-        configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,6 +7,17 @@ spring:
       hibernate:
         format_sql: false
 
+  servlet:
+    session:
+      cookie:
+        domain: .timiroom.kro.kr
+        same-site: lax
+        secure: true
+        http-only: true
+
+cors:
+  allowed-origins: "https://timiroom.kro.kr"
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,6 @@ spring:
 server:
   port: 8080
 
+cors:
+  allowed-origins: "http://localhost:3000"
+


### PR DESCRIPTION
## 변경 내용

### 메인 백엔드
- `SecurityConfig`: CORS allowed-origins 하드코딩 → `@Value` 환경변수 기반으로 변경
- `application.yml`: `cors.allowed-origins` 로컬 기본값 추가 (`http://localhost:3000`)
- `application-prod.yml`: CORS prod 설정 및 Spring Session 쿠키 설정
  - `cors.allowed-origins: https://timiroom.kro.kr`
  - 쿠키 도메인: `.timiroom.kro.kr` (프론트/백엔드 서브도메인 간 세션 공유)
  - `secure: true`, `http-only: true`, `same-site: lax`

### RAG Pipeline
- `CorsConfig`: 하드코딩 origin → `@Value` 환경변수 기반으로 변경
- `application.yml`: `cors.allowed-origins` 로컬 기본값 추가
- `application-prod.yml`: `cors.allowed-origins: https://timiroom.kro.kr` 추가

## 배경
- 프론트(`timiroom.kro.kr`)와 백엔드(`api.timiroom.kro.kr`), RAG(`rag.timiroom.kro.kr`)를
  각각 서브도메인으로 분리 운영
- CORS 및 세션 쿠키를 서브도메인 간 공유 가능하도록 설정

## 체크리스트
- [x] 로컬 환경 기본값 유지 (`http://localhost:3000`)
- [x] prod 환경 CORS 설정
- [x] 세션 쿠키 도메인 설정 (`.timiroom.kro.kr`)
- [x] RAG pipeline CORS 설정 통일