### PR TITLE
[ci] develop 기준 백엔드 배포 설정 정리

### DIFF
--- a/.github/workflows/deploy-rag.yml
+++ b/.github/workflows/deploy-rag.yml
@@ -2,7 +2,7 @@ name: Rag-Pipeline CI/CD
 
 on:
   push:
-    branches: [ main ]
+    branches: [ develop ]
     paths:
       - 'rag-pipeline/**'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Backend CI/CD
 
 on:
   push:
-    branches: [ main ]
+    branches: [ develop ]
     paths-ignore:
       - 'rag-pipeline/**'
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,3 +71,8 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+// 실행 불가능한 plain jar 생성 비활성화 (Docker COPY build/libs/*.jar 충돌 방지)
+jar {
+	enabled = false
+}

--- a/rag-pipeline/build.gradle
+++ b/rag-pipeline/build.gradle
@@ -75,3 +75,8 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+// 실행 불가능한 plain jar 생성 비활성화 (Docker COPY build/libs/*.jar 충돌 방지)
+jar {
+    enabled = false
+}

--- a/rag-pipeline/src/main/resources/application-prod.yml
+++ b/rag-pipeline/src/main/resources/application-prod.yml
@@ -2,6 +2,10 @@
 # 민감 정보는 환경변수로 관리합니다.
 # 필요 환경변수: DB_URL, DB_USERNAME, DB_PASSWORD, KAFKA_BOOTSTRAP_SERVERS
 
+# ── 서버 포트 (k8s 매니페스트/서비스와 일치, 로컬은 base의 8081 사용) ──
+server:
+  port: 8080
+
 cors:
   allowed-origins: "https://timiroom.kro.kr"
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,9 +28,6 @@ spring:
         secure: true
         http-only: true
 
-cors:
-  allowed-origins: "https://timiroom.kro.kr"
-
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -50,3 +47,6 @@ cors:
       password: ${REDIS_PASSWORD}
       ssl:
         enabled: ${REDIS_SSL_ENABLED}
+
+cors:
+  allowed-origins: "https://timiroom.kro.kr"


### PR DESCRIPTION
## 작업 내용
- 백엔드와 Rag-Pipeline 배포 워크플로우가 `main`이 아니라 `develop` 브랜치에 push될 때 실행되도록 변경했습니다.
- `application-prod.yml`에서 `datasource`, `neo4j`, `redis` 설정이 `spring` 설정 아래에 적용되도록 들여쓰기를 수정했습니다.
- Rag-Pipeline의 운영 포트를 Kubernetes 서비스와 헬스 체크 설정에 맞춰 `8080`으로 통일했습니다.
- Docker 이미지 빌드 시 실행 JAR과 일반 JAR이 함께 생성되어 충돌하지 않도록 plain JAR 생성을 비활성화했습니다.

## 영향 범위
- 앞으로 `develop`에 병합된 변경이 Docker 이미지 빌드/푸시와 `timiroom-ops` 매니페스트 업데이트 배포 흐름을 실행합니다.
- 백엔드와 Rag-Pipeline 모두 운영 환경 설정 기준으로 컨테이너가 더 안정적으로 기동되도록 정리했습니다.

## 검증
- `./gradlew.bat build -x test --no-daemon` 성공
- `rag-pipeline`에서 `./gradlew.bat build -x test --no-daemon` 성공
- `kubectl kustomize D:\git\timiroom-ops\apps\backend` 성공
- `kubectl kustomize D:\git\timiroom-ops\apps\rag-pipeline` 성공

## 배포 전 확인 필요
- GitHub Actions `production` 환경에 `APP_*`, `RAG_*`, `GH_PAT`, `DOCKER_*` secrets가 올바르게 등록되어 있어야 실제 배포가 정상 동작합니다.