### PR TITLE
fix: SealedSecret 생성 시 namespace 지정

### DIFF
--- a/.github/workflows/deploy-rag.yml
+++ b/.github/workflows/deploy-rag.yml
@@ -53,7 +53,7 @@ jobs:
           rm -f temp-secrets.env
           echo "$ALL_SECRETS_JSON" | jq -r 'to_entries[] | select(.key | startswith("RAG_")) | "\(.key | sub("^RAG_"; ""))=\(.value)"' > temp-secrets.env
 
-          kubectl create secret generic rag-pipeline-secrets --from-env-file=temp-secrets.env --dry-run=client -o yaml > plain-secret.yaml
+          kubectl create secret generic rag-pipeline-secrets -n timiroom --from-env-file=temp-secrets.env --dry-run=client -o yaml > plain-secret.yaml
           kubeseal --format=yaml --cert=pub-cert.pem < plain-secret.yaml > sealed-secret.yaml
           rm -f temp-secrets.env plain-secret.yaml
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
           rm -f temp-secrets.env
           echo "$ALL_SECRETS_JSON" | jq -r 'to_entries[] | select(.key | startswith("APP_")) | "\(.key | sub("^APP_"; ""))=\(.value)"' > temp-secrets.env
           
-          kubectl create secret generic backend-secrets --from-env-file=temp-secrets.env --dry-run=client -o yaml > plain-secret.yaml
+          kubectl create secret generic backend-secrets -n timiroom --from-env-file=temp-secrets.env --dry-run=client -o yaml > plain-secret.yaml
           
           kubeseal --format=yaml --cert=pub-cert.pem < plain-secret.yaml > sealed-secret.yaml
           


### PR DESCRIPTION
## 작업 내용
- Backend 배포 워크플로우에서 `backend-secrets` plain Secret 생성 시 `timiroom` namespace를 명시했습니다.
- Rag-Pipeline 배포 워크플로우에서 `rag-pipeline-secrets` plain Secret 생성 시 `timiroom` namespace를 명시했습니다.

## 원인
- GitHub Actions 환경에는 kubeconfig가 없어, namespace가 없는 plain Secret을 `kubeseal`에 넘기면 namespace를 추론하지 못하고 실패했습니다.

## 영향 범위
- Docker 이미지 빌드/푸시 로직은 그대로 유지됩니다.
- SealedSecret 생성 단계에서 namespace가 포함되어 ops repo 매니페스트 업데이트 단계가 정상 진행되도록 합니다.

## 검증
- `git diff --check`
- `kubectl create secret generic backend-secrets -n timiroom --from-literal=DB_USERNAME=dummy --dry-run=client -o yaml`
- `kubectl create secret generic rag-pipeline-secrets -n timiroom --from-literal=DB_USERNAME=dummy --dry-run=client -o yaml`

## 배포 전 확인 필요
- GitHub Actions `production` 환경에 `APP_DB_USERNAME`, `RAG_DB_USERNAME`을 추가해야 합니다.