### PR TITLE
[codex] 백엔드 배포 health check 기동 문제 수정

### DIFF
--- a/src/main/java/com/timiroom/config/SecurityConfig.java
+++ b/src/main/java/com/timiroom/config/SecurityConfig.java
@@ -15,10 +15,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.savedrequest.NullRequestCache;
 
 import java.util.Arrays;
-import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -44,6 +42,7 @@ public class SecurityConfig {
                         })
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/health", "/actuator/health/**").permitAll()
                         .requestMatchers("/auth/**", "/oauth2/**", "/login/**", "/error").permitAll()
                         .requestMatchers("/api/v1/pipeline/**").authenticated()
                         .anyRequest().authenticated()

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,7 +14,7 @@ rag-pipeline:
 spring:
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
     show-sql: false
     properties:
       hibernate:


### PR DESCRIPTION
## 작업 내용
- `/actuator/health` 및 하위 health probe endpoint를 인증 예외로 추가했습니다.
- prod JPA DDL 전략을 `SPRING_JPA_HIBERNATE_DDL_AUTO`로 오버라이드 가능하게 하고, 기본값을 `update`로 조정했습니다.
- 사용하지 않는 SecurityConfig import를 정리했습니다.

## 영향 범위
- Kubernetes HTTP liveness/readiness probe가 인증 없이 health endpoint를 호출할 수 있습니다.
- 마이그레이션 도구가 없는 현재 구성에서 prod DB에 누락된 테이블이 있으면 애플리케이션이 기동 중 생성할 수 있습니다.
- 이미 서버에서 수동 오버라이드로 백엔드 Pod 2개가 정상 기동 중이며, 이 변경은 재배포 후 같은 문제가 반복되지 않도록 합니다.

## 검증
- `./gradlew.bat build -x test --no-daemon` 성공
- 서버에서 backend Pod 2개 `1/1 Running`, restart 0 확인
- `https://api.timiroom.kro.kr/auth/me`가 502 대신 백엔드 `401` 응답 반환 확인

## 참고
- 관련 ops PR: https://github.com/timiroom/timiroom-ops/pull/1
- ops PR이 먼저 반영되어야 서버 NodePort/Redis TLS 설정이 재배포 후에도 유지됩니다.