### PR TITLE
fix: restore missing List import in SecurityConfig

### DIFF
--- a/src/main/java/com/timiroom/config/SecurityConfig.java
+++ b/src/main/java/com/timiroom/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor


### PR DESCRIPTION
## What changed
- Added the missing `java.util.List` import in `SecurityConfig`

## Why
- `SecurityConfig` uses `List.of(...)` in the CORS config
- The import disappeared during merge, so `:compileJava` failed and the backend image build was blocked

## Validation
- Ran `.\gradlew.bat clean build -x test --no-daemon` on a clean `origin/develop` worktree
- Build passed successfully