### PR TITLE
feat: GitHub 정합성 검증과 이슈 동기화 강화

### DIFF
--- a/src/main/java/com/timiroom/domain/github/GithubIssueController.java
+++ b/src/main/java/com/timiroom/domain/github/GithubIssueController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,7 +49,28 @@ public class GithubIssueController {
         }
         try {
             return ResponseEntity.status(201).body(githubIssueService.create(projectId, memberId, repoId,
-                    title, asString(body.get("body")), labels(body.get("labels"))));
+                    title, asString(body.get("body")), labels(body.get("labels")),
+                    asLong(body.get("ownerMemberId"))));
+        } catch (SecurityException e) {
+            return ResponseEntity.status(403).body(Map.of("error", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(502).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @PatchMapping("/{repoId}/{issueNumber}")
+    public ResponseEntity<?> update(HttpSession session, @PathVariable Long projectId,
+                                    @PathVariable Long repoId, @PathVariable int issueNumber,
+                                    @RequestBody Map<String, Object> body) {
+        Long memberId = memberId(session);
+        if (memberId == null) return unauthorized();
+        try {
+            return ResponseEntity.ok(githubIssueService.update(projectId, memberId, repoId, issueNumber,
+                    asString(body.get("title")), asString(body.get("body")),
+                    body.containsKey("labels") ? labels(body.get("labels")) : null,
+                    asLong(body.get("ownerMemberId"))));
         } catch (SecurityException e) {
             return ResponseEntity.status(403).body(Map.of("error", e.getMessage()));
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/timiroom/domain/github/GithubIssueService.java
+++ b/src/main/java/com/timiroom/domain/github/GithubIssueService.java
@@ -1,6 +1,8 @@
 package com.timiroom.domain.github;
 
 import com.timiroom.domain.github.dto.ProjectGithubIssueResponse;
+import com.timiroom.domain.member.Member;
+import com.timiroom.domain.member.MemberRepository;
 import com.timiroom.domain.project.ProjectMember;
 import com.timiroom.domain.project.ProjectMemberRepository;
 import com.timiroom.domain.project.ProjectRole;
@@ -23,6 +25,7 @@ public class GithubIssueService {
     private final ProjectMemberRepository projectMemberRepository;
     private final ProjectRepoLinkRepository projectRepoLinkRepository;
     private final GithubRepoRepository githubRepoRepository;
+    private final MemberRepository memberRepository;
     private final GithubClient githubClient;
 
     @Transactional(readOnly = true)
@@ -41,12 +44,44 @@ public class GithubIssueService {
     @Transactional
     public ProjectGithubIssueResponse create(Long projectId, Long memberId, Long repoId,
                                               String title, String body, List<String> labels) {
+        return create(projectId, memberId, repoId, title, body, labels, null);
+    }
+
+    @Transactional
+    public ProjectGithubIssueResponse create(Long projectId, Long memberId, Long repoId,
+                                              String title, String body, List<String> labels,
+                                              Long ownerMemberId) {
         if (title == null || title.isBlank()) throw new IllegalArgumentException("이슈 제목은 필수입니다");
         GithubRepo repo = findLinkedRepo(projectId, memberId, repoId);
         requirePm(projectId, memberId);
+        List<String> assignees = findAssignees(projectId, ownerMemberId);
         GithubIssueInfo created = githubClient.createIssue(repo.getFullName(), repo.getInstallationId(),
-                title.trim(), body, labels == null ? List.of() : labels);
+                title.trim(), body, labels == null ? List.of() : labels, assignees);
         return toResponse(repo, created);
+    }
+
+    @Transactional
+    public ProjectGithubIssueResponse update(Long projectId, Long memberId, Long repoId, int issueNumber,
+                                              String title, String body, List<String> labels,
+                                              Long ownerMemberId) {
+        if (issueNumber < 1) throw new IllegalArgumentException("올바른 이슈 번호가 필요합니다");
+        if (title != null && title.isBlank()) throw new IllegalArgumentException("이슈 제목은 비울 수 없습니다");
+        GithubRepo repo = findLinkedRepo(projectId, memberId, repoId);
+        requirePm(projectId, memberId);
+        GithubIssueInfo updated = githubClient.updateIssue(repo.getFullName(), repo.getInstallationId(), issueNumber,
+                title == null ? null : title.trim(), body, labels, findAssignees(projectId, ownerMemberId));
+        return toResponse(repo, updated);
+    }
+
+    private List<String> findAssignees(Long projectId, Long ownerMemberId) {
+        if (ownerMemberId == null) return List.of();
+        projectMemberRepository.findByProjectIdAndMemberId(projectId, ownerMemberId)
+                .orElseThrow(() -> new IllegalArgumentException("담당자는 프로젝트 멤버여야 합니다"));
+        Member owner = memberRepository.findById(ownerMemberId)
+                .orElseThrow(() -> new IllegalArgumentException("담당자 계정을 찾을 수 없습니다"));
+        return owner.getGithubLogin() == null || owner.getGithubLogin().isBlank()
+                ? List.of()
+                : List.of(owner.getGithubLogin());
     }
 
     private GithubRepo findLinkedRepo(Long projectId, Long memberId, Long repoId) {
@@ -59,9 +94,9 @@ public class GithubIssueService {
 
     private void requirePm(Long projectId, Long memberId) {
         ProjectMember member = projectMemberRepository.findByProjectIdAndMemberId(projectId, memberId)
-                .orElseThrow(() -> new SecurityException("이슈를 생성할 프로젝트 권한이 없습니다"));
+                .orElseThrow(() -> new SecurityException("이슈를 관리할 프로젝트 권한이 없습니다"));
         if (member.getProjectRole() != ProjectRole.PM) {
-            throw new SecurityException("이슈 생성은 PM만 할 수 있습니다");
+            throw new SecurityException("이슈 관리는 PM만 할 수 있습니다");
         }
     }
 

--- a/src/main/java/com/timiroom/domain/github/GithubPullRequestReviewRecord.java
+++ b/src/main/java/com/timiroom/domain/github/GithubPullRequestReviewRecord.java
@@ -57,6 +57,10 @@ public class GithubPullRequestReviewRecord {
     @Column(name = "findings_json", columnDefinition = "TEXT")
     private String findingsJson;
 
+    /** 실제 판정기 식별자. 중복 검사 응답에서도 원래 판정기를 그대로 노출한다. */
+    @Column(name = "evaluator", length = 40)
+    private String evaluator;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -71,8 +75,9 @@ public class GithubPullRequestReviewRecord {
         this.checkRunUrl = checkRunUrl;
     }
 
-    public void updateResult(Integer score, String findingsJson) {
+    public void updateResult(Integer score, String findingsJson, String evaluator) {
         this.score = score;
         this.findingsJson = findingsJson;
+        this.evaluator = evaluator;
     }
 }

--- a/src/main/java/com/timiroom/domain/github/GithubPullRequestReviewRecordRepository.java
+++ b/src/main/java/com/timiroom/domain/github/GithubPullRequestReviewRecordRepository.java
@@ -3,6 +3,7 @@ package com.timiroom.domain.github;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface GithubPullRequestReviewRecordRepository extends JpaRepository<GithubPullRequestReviewRecord, Long> {
@@ -10,5 +11,8 @@ public interface GithubPullRequestReviewRecordRepository extends JpaRepository<G
             Long projectId, Long githubRepoId, Integer pullNumber);
 
     Optional<GithubPullRequestReviewRecord> findFirstByProjectIdAndGithubRepoIdInOrderByUpdatedAtDesc(
+            Long projectId, Collection<Long> githubRepoIds);
+
+    List<GithubPullRequestReviewRecord> findByProjectIdAndGithubRepoIdIn(
             Long projectId, Collection<Long> githubRepoIds);
 }

--- a/src/main/java/com/timiroom/domain/github/PullRequestConsistencyService.java
+++ b/src/main/java/com/timiroom/domain/github/PullRequestConsistencyService.java
@@ -3,6 +3,7 @@ package com.timiroom.domain.github;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.timiroom.domain.github.dto.ConsistencyFinding;
+import com.timiroom.domain.github.dto.EvidenceReference;
 import com.timiroom.domain.github.dto.ProjectConsistencySummary;
 import com.timiroom.domain.github.dto.ProjectPullRequestResponse;
 import com.timiroom.domain.github.dto.PullRequestConsistencyResult;
@@ -34,6 +35,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -52,6 +54,10 @@ public class PullRequestConsistencyService {
     private static final Pattern TABLE_SQL = Pattern.compile("(?:create|alter)\\s+table\\s+(?:if\\s+not\\s+exists\\s+)?([a-zA-Z0-9_.]+)", Pattern.CASE_INSENSITIVE);
     private static final Pattern ISSUE_REFERENCE = Pattern.compile("(?<![A-Za-z0-9_])#(\\d+)");
     private static final Pattern BRANCH_PREFIX = Pattern.compile("^(?:feature|fix|hotfix|refactor|docs|chore)/", Pattern.CASE_INSENSITIVE);
+    private static final Pattern AT_TOKEN = Pattern.compile("(?<![A-Za-z0-9_`])@([A-Za-z_][A-Za-z0-9_-]*)");
+    private static final Pattern REVIEWABLE_SOURCE = Pattern.compile(
+            ".*\\.(?:java|kt|kts|py|js|jsx|ts|tsx|sql|yml|yaml|json)$", Pattern.CASE_INSENSITIVE);
+    private static final int MAX_CONTEXT_FILES = 15;
 
     private final ProjectService projectService;
     private final ProjectMemberRepository projectMemberRepository;
@@ -85,7 +91,16 @@ public class PullRequestConsistencyService {
                 .sorted(Comparator.comparing(item -> item.pullRequest().updatedAt(),
                         Comparator.nullsLast(Comparator.reverseOrder())))
                 .toList();
-        return pulls.stream().map(pull -> toResponse(pull.repo(), pull.pullRequest(), relatedPullRequests(pull, pulls))).toList();
+        Map<String, GithubPullRequestReviewRecord> records = pulls.isEmpty()
+                ? Map.of()
+                : reviewRecordRepository.findByProjectIdAndGithubRepoIdIn(projectId,
+                                pulls.stream().map(item -> item.repo().getId()).distinct().toList())
+                        .stream().collect(java.util.stream.Collectors.toMap(
+                                record -> reviewKey(record.getGithubRepoId(), record.getPullNumber()),
+                                record -> record,
+                                (left, right) -> left));
+        return pulls.stream().map(pull -> toResponse(pull.repo(), pull.pullRequest(),
+                relatedPullRequests(pull, pulls), records)).toList();
     }
 
     @Transactional
@@ -109,33 +124,37 @@ public class PullRequestConsistencyService {
         if (existing != null && pullRequest.headSha() != null && pullRequest.headSha().equals(existing.getHeadSha())) {
             return new PullRequestConsistencyResult(repo.getId(), pullNumber, pullRequest.headSha(),
                     existing.getScore() != null ? existing.getScore() : 0,
-                    false, true, existing.getReviewUrl(), existing.getCheckRunUrl(), "CACHED",
+                    false, true, existing.getReviewUrl(), existing.getCheckRunUrl(),
+                    existing.getEvaluator() != null ? existing.getEvaluator() : "CACHED",
                     readFindings(existing.getFindingsJson()));
         }
 
-        List<GithubPullRequestFileInfo> files = githubClient.listPullRequestFiles(repo.getFullName(), repo.getInstallationId(), pullNumber);
+        List<GithubPullRequestFileInfo> files = withFullFileContext(repo, pullRequest,
+                githubClient.listPullRequestFiles(repo.getFullName(), repo.getInstallationId(), pullNumber));
         Map<PipelineArtifact.ArtifactType, String> specifications = latestSpecifications(projectId);
         AnalysisOutcome analysis = analyzeWithAgent(repo, pullRequest, files, specifications);
         List<ConsistencyFinding> findings = analysis.findings();
         long warningCount = findings.stream().filter(f -> "WARNING".equals(f.severity())).count();
-        int score = Math.max(0, 100 - (int) warningCount * 25);
+        long inconclusiveCount = findings.stream().filter(f -> "INCONCLUSIVE".equals(f.severity())).count();
+        long attentionCount = warningCount + inconclusiveCount;
+        int score = inconclusiveCount > 0 ? 0 : Math.max(0, 100 - (int) warningCount * 25);
         String findingsJson = writeFindings(findings);
 
-        String reviewBody = reviewMarkdown(score, findings, analysis.evaluator());
+        String reviewBody = reviewMarkdown(score, findings, analysis.evaluator(), analysis.summary(), pullRequest);
         GithubCheckRunInfo checkRun = githubClient.createCompletedConsistencyCheckRun(repo.getFullName(),
-                repo.getInstallationId(), pullRequest.headSha(), score, warningCount > 0, reviewBody);
+                repo.getInstallationId(), pullRequest.headSha(), score, inconclusiveCount > 0, reviewBody);
         GithubPullRequestReviewInfo review = githubClient.createPullRequestCommentReview(repo.getFullName(),
                 repo.getInstallationId(), pullNumber, pullRequest.headSha(), reviewBody);
         if (existing == null) {
             reviewRecordRepository.save(GithubPullRequestReviewRecord.builder()
                     .projectId(projectId).githubRepoId(repo.getId()).pullNumber(pullNumber)
                     .headSha(pullRequest.headSha()).reviewUrl(review.htmlUrl()).checkRunUrl(checkRun.htmlUrl())
-                    .score(score).findingsJson(findingsJson).build());
+                    .score(score).findingsJson(findingsJson).evaluator(analysis.evaluator()).build());
         } else {
             existing.updateReview(pullRequest.headSha(), review.htmlUrl(), checkRun.htmlUrl());
-            existing.updateResult(score, findingsJson);
+            existing.updateResult(score, findingsJson, analysis.evaluator());
         }
-        if (warningCount > 0) notifyProjectMembers(projectId, repo, pullNumber, warningCount);
+        if (attentionCount > 0) notifyProjectMembers(projectId, repo, pullNumber, warningCount, inconclusiveCount);
         return new PullRequestConsistencyResult(repo.getId(), pullNumber, pullRequest.headSha(), score,
                 true, false, review.htmlUrl(), checkRun.htmlUrl(), analysis.evaluator(), findings);
     }
@@ -155,7 +174,8 @@ public class PullRequestConsistencyService {
         if (repo == null) return null;
         return new ProjectConsistencySummary(repo.getId(), repo.getFullName(), record.getPullNumber(),
                 record.getScore() != null ? record.getScore() : 0, record.getReviewUrl(), record.getCheckRunUrl(),
-                record.getUpdatedAt(), readFindings(record.getFindingsJson()));
+                record.getUpdatedAt(), record.getEvaluator() != null ? record.getEvaluator() : "CACHED",
+                readFindings(record.getFindingsJson()));
     }
 
     private String writeFindings(List<ConsistencyFinding> findings) {
@@ -175,10 +195,12 @@ public class PullRequestConsistencyService {
         }
     }
 
-    private void notifyProjectMembers(Long projectId, GithubRepo repo, int pullNumber, long warningCount) {
+    private void notifyProjectMembers(Long projectId, GithubRepo repo, int pullNumber,
+                                      long warningCount, long inconclusiveCount) {
         String title = "PR 정합성 확인 필요";
-        String content = repo.getFullName() + " #" + pullNumber + "에서 " + warningCount
-                + "개의 명세 정합성 경고가 발견됐습니다.";
+        String detail = warningCount > 0 ? warningCount + "개의 명세 정합성 경고"
+                : "근거 부족으로 인한 판정 보류 " + inconclusiveCount + "건";
+        String content = repo.getFullName() + " #" + pullNumber + "에서 " + detail + "이 발견됐습니다.";
         projectMemberRepository.findByProjectId(projectId).forEach(member -> notificationService.create(
                 member.getMemberId(), NotificationType.PR_CONSISTENCY_REVIEW, title, content,
                 NotificationReferenceType.PULL_REQUEST, (long) pullNumber));
@@ -190,12 +212,32 @@ public class PullRequestConsistencyService {
         return result;
     }
 
+    private List<GithubPullRequestFileInfo> withFullFileContext(GithubRepo repo,
+                                                                GithubPullRequestInfo pullRequest,
+                                                                List<GithubPullRequestFileInfo> files) {
+        int[] fetched = {0};
+        return files.stream().map(file -> {
+            if (fetched[0] >= MAX_CONTEXT_FILES || !REVIEWABLE_SOURCE.matcher(file.filename()).matches()) {
+                return file;
+            }
+            fetched[0]++;
+            String content = "removed".equalsIgnoreCase(file.status()) ? null
+                    : githubClient.getRepositoryFileContent(repo.getFullName(), repo.getInstallationId(),
+                            file.filename(), pullRequest.headSha()).orElse(null);
+            String baseContent = "added".equalsIgnoreCase(file.status()) ? null
+                    : githubClient.getRepositoryFileContent(repo.getFullName(), repo.getInstallationId(),
+                            file.filename(), pullRequest.baseRef()).orElse(null);
+            return file.withContents(content, baseContent);
+        }).toList();
+    }
+
     private AnalysisOutcome analyzeWithAgent(GithubRepo repo,
                                              GithubPullRequestInfo pullRequest,
                                              List<GithubPullRequestFileInfo> files,
                                              Map<PipelineArtifact.ArtifactType, String> specifications) {
         if (!agentEnabled) {
-            return new AnalysisOutcome(analyzeWithRules(files, specifications), "RULES");
+            List<ConsistencyFinding> findings = analyzeWithRules(files, specifications);
+            return new AnalysisOutcome(findings, "RULES", defaultReviewSummary(findings));
         }
         try {
             String runtime = normalizedAgentRuntime();
@@ -206,22 +248,52 @@ public class PullRequestConsistencyService {
             List<ConsistencyFinding> findings = new ArrayList<>();
             for (JsonNode finding : response.path("findings")) {
                 String severity = finding.path("severity").asText("INFO").toUpperCase();
-                if (!Set.of("PASS", "INFO", "WARNING").contains(severity)) severity = "INFO";
+                if (!Set.of("PASS", "INFO", "WARNING", "INCONCLUSIVE").contains(severity)) severity = "INFO";
                 String area = finding.path("area").asText("Agent").trim();
                 String message = finding.path("message").asText("").trim();
-                if (!message.isBlank()) findings.add(new ConsistencyFinding(severity, area, message));
+                List<String> evidence = new ArrayList<>();
+                JsonNode evidenceNode = finding.path("evidence");
+                if (evidenceNode.isArray()) {
+                    for (JsonNode item : evidenceNode) {
+                        String value = item.asText("").trim();
+                        if (!value.isBlank() && evidence.size() < 4) evidence.add(value);
+                    }
+                } else if (evidenceNode.isTextual() && !evidenceNode.asText().isBlank()) {
+                    evidence.add(evidenceNode.asText().trim());
+                }
+                String recommendation = finding.path("recommendation").asText("").trim();
+                List<EvidenceReference> references = new ArrayList<>();
+                if (finding.path("references").isArray()) {
+                    for (JsonNode reference : finding.path("references")) {
+                        String sourceType = reference.path("sourceType").asText("").trim();
+                        String source = reference.path("source").asText("").trim();
+                        String quote = reference.path("quote").asText("").trim();
+                        Integer line = reference.path("line").canConvertToInt() ? reference.path("line").asInt() : null;
+                        if (!sourceType.isBlank() && !source.isBlank() && !quote.isBlank() && references.size() < 4) {
+                            references.add(new EvidenceReference(sourceType, source, line, quote));
+                        }
+                    }
+                }
+                if (!message.isBlank()) findings.add(new ConsistencyFinding(severity, area, message,
+                        List.copyOf(evidence), List.copyOf(references),
+                        recommendation.isBlank() ? null : recommendation));
             }
             if (findings.isEmpty()) {
                 throw new IllegalStateException("Consistency Agent가 finding을 반환하지 않았습니다");
             }
-            return new AnalysisOutcome(List.copyOf(findings),
-                    "PYTHON".equals(runtime) ? "PYTHON_EXAONE" : "SPRING_FOUNDRY");
+            String evaluator = "SPRING".equals(runtime)
+                    ? "SPRING_FOUNDRY"
+                    : "EXAONE_FACT_GATE".equals(response.path("evaluationMode").asText())
+                            ? "PYTHON_EXAONE_FACT_GATE"
+                            : "PYTHON_EXAONE";
+            return new AnalysisOutcome(List.copyOf(findings), evaluator,
+                    response.path("summary").asText(defaultReviewSummary(findings)).trim());
         } catch (Exception e) {
             log.warn("PR Consistency Agent 실패 — 규칙 엔진 fallback: {}", e.getMessage());
             List<ConsistencyFinding> findings = new ArrayList<>(analyzeWithRules(files, specifications));
             findings.add(new ConsistencyFinding("INFO", "검사기",
                     "Consistency Agent를 사용할 수 없어 규칙 기반 검사 결과를 사용했습니다."));
-            return new AnalysisOutcome(List.copyOf(findings), "RULE_FALLBACK");
+            return new AnalysisOutcome(List.copyOf(findings), "RULE_FALLBACK", defaultReviewSummary(findings));
         }
     }
 
@@ -246,6 +318,9 @@ public class PullRequestConsistencyService {
             changedFile.put("additions", file.additions());
             changedFile.put("deletions", file.deletions());
             changedFile.put("patch", file.patch());
+            changedFile.put("content", file.content());
+            changedFile.put("baseContent", file.baseContent());
+            changedFile.put("patchTruncated", file.patchTruncated());
             return changedFile;
         }).toList());
         return request;
@@ -362,29 +437,147 @@ public class PullRequestConsistencyService {
         return keys;
     }
 
-    private String reviewMarkdown(int score, List<ConsistencyFinding> findings, String evaluator) {
-        String evaluatorDescription = switch (evaluator) {
-            case "PYTHON_EXAONE" -> "독립 Python `PR Consistency Agent`가 Friendli의 LG K-EXAONE으로 최신 명세와 변경 diff를 검토했습니다.";
-            case "SPRING_FOUNDRY" -> "Spring `PR Consistency Agent`가 해외 Foundry 모델로 최신 명세와 변경 diff를 검토했습니다.";
-            case "AGENT" -> "전용 `PR Consistency Agent`가 최신 명세와 변경 diff를 의미 단위로 검토했습니다.";
-            case "RULE_FALLBACK" -> "Consistency Agent 호출에 실패해 규칙 엔진이 최신 명세와 변경 diff를 대조했습니다.";
-            default -> "규칙 엔진이 최신 명세와 변경 diff를 대조했습니다.";
-        };
-        StringBuilder body = new StringBuilder("## timiroom 정합성 자동 리뷰\n\n")
-                .append("> ").append(evaluatorDescription)
-                .append(" 자동 승인이나 변경 요청은 하지 않습니다.\n\n")
-                .append("**점수: ").append(score).append("/100**\n\n");
-        for (ConsistencyFinding finding : findings) {
-            String icon = switch (finding.severity()) {
-                case "PASS" -> "✅";
-                case "WARNING" -> "⚠️";
-                default -> "ℹ️";
-            };
-            body.append("- ").append(icon).append(" **").append(finding.area()).append("** — ")
-                    .append(finding.message()).append("\n");
+    private String reviewMarkdown(int score,
+                                  List<ConsistencyFinding> findings,
+                                  String evaluator,
+                                  String summary,
+                                  GithubPullRequestInfo pullRequest) {
+        List<ConsistencyFinding> warnings = findings.stream()
+                .filter(finding -> "WARNING".equals(finding.severity())).toList();
+        List<ConsistencyFinding> passes = findings.stream()
+                .filter(finding -> "PASS".equals(finding.severity())).toList();
+        List<ConsistencyFinding> information = findings.stream()
+                .filter(finding -> !Set.of("WARNING", "PASS", "INCONCLUSIVE").contains(finding.severity())).toList();
+        List<ConsistencyFinding> inconclusive = findings.stream()
+                .filter(finding -> "INCONCLUSIVE".equals(finding.severity())).toList();
+        boolean needsAttention = !warnings.isEmpty() || !inconclusive.isEmpty();
+
+        StringBuilder body = new StringBuilder("## 🔍 timiroom PR 정합성 리뷰\n\n")
+                .append(needsAttention ? "> [!WARNING]\n" : "> [!NOTE]\n")
+                .append("> ")
+                .append(needsAttention
+                        ? (!warnings.isEmpty()
+                                ? "병합 전에 확인할 정합성 경고가 **" + warnings.size() + "건** 있습니다."
+                                : "확정 근거가 부족해 정합성 판정을 보류했습니다.")
+                        : "명세와 구현 사이에서 병합을 막을 정합성 문제를 찾지 못했습니다.")
+                .append("\n\n")
+                .append("| 항목 | 결과 |\n| --- | --- |\n")
+                .append("| 상태 | ").append(!inconclusive.isEmpty() ? "❔ 판정 보류" : needsAttention ? "⚠️ 검토 필요" : "✅ 통과").append(" |\n")
+                .append("| 정합성 점수 | ").append(!inconclusive.isEmpty() ? "**—**" : "**" + score + "/100**").append(" |\n")
+                .append("| 리뷰 엔진 | ").append(evaluatorLabel(evaluator)).append(" |\n")
+                .append("| 비교 범위 | 최신 API·DB 명세 ↔ PR 변경 원문·diff |\n")
+                .append("| 브랜치 | `").append(tableText(pullRequest.headRef())).append("` → `")
+                .append(tableText(pullRequest.baseRef())).append("` |\n\n")
+                .append("### 리뷰 요약\n\n")
+                .append("> ").append(markdownText(summary == null || summary.isBlank()
+                        ? defaultReviewSummary(findings) : summary)).append("\n\n");
+
+        if (!warnings.isEmpty()) {
+            body.append("### ⚠️ 병합 전 확인 사항\n\n");
+            warnings.forEach(finding -> appendFindingDetails(body, finding, true));
         }
-        body.append("\n---\n_timiroom GitHub App이 같은 PR head SHA에는 이 리뷰를 한 번만 게시합니다._");
+        if (!passes.isEmpty()) {
+            body.append("### ✅ 확인된 항목\n\n");
+            passes.forEach(finding -> body.append("- **").append(markdownText(finding.area()))
+                    .append("** — ").append(markdownText(finding.message())).append("\n"));
+            body.append("\n");
+        }
+        if (!inconclusive.isEmpty()) {
+            body.append("### ❔ 판정 보류\n\n");
+            inconclusive.forEach(finding -> appendFindingDetails(body, finding, true));
+        }
+        if (!information.isEmpty()) {
+            body.append("<details>\n<summary><strong>ℹ️ 참고 사항 ")
+                    .append(information.size()).append("건</strong></summary>\n\n");
+            information.forEach(finding -> body.append("- **").append(markdownText(finding.area()))
+                    .append("** — ").append(markdownText(finding.message())).append("\n"));
+            body.append("\n</details>\n\n");
+        }
+
+        body.append("---\n")
+                .append("<sub>").append(evaluatorDescription(evaluator))
+                .append(" 자동 승인이나 변경 요청은 하지 않습니다. 동일한 head SHA (`")
+                .append(shortSha(pullRequest.headSha()))
+                .append("`)에는 리뷰를 한 번만 게시합니다.</sub>");
         return body.toString();
+    }
+
+    private void appendFindingDetails(StringBuilder body, ConsistencyFinding finding, boolean open) {
+        body.append("<details").append(open ? " open" : "").append(">\n")
+                .append("<summary><strong>").append(htmlText(finding.area())).append("</strong> — ")
+                .append(htmlText(finding.message())).append("</summary>\n\n");
+        if (!finding.evidence().isEmpty()) {
+            body.append("**근거**\n\n");
+            finding.evidence().forEach(evidence -> body.append("- ").append(markdownText(evidence)).append("\n"));
+            body.append("\n");
+        }
+        if (!finding.references().isEmpty()) {
+            body.append("**원문 위치**\n\n");
+            finding.references().forEach(reference -> body.append("- `")
+                    .append(markdownText(reference.source()))
+                    .append(reference.line() == null ? "" : ":" + reference.line())
+                    .append("` — ").append(markdownText(reference.quote())).append("\n"));
+            body.append("\n");
+        }
+        if (finding.recommendation() != null && !finding.recommendation().isBlank()) {
+            body.append("**권장 수정**\n\n")
+                    .append(markdownText(finding.recommendation())).append("\n\n");
+        }
+        body.append("</details>\n\n");
+    }
+
+    private String evaluatorLabel(String evaluator) {
+        return switch (evaluator) {
+            case "PYTHON_EXAONE" -> "🇰🇷 LG EXAONE Agent";
+            case "PYTHON_EXAONE_FACT_GATE" -> "🇰🇷 LG EXAONE + Fact Gate";
+            case "SPRING_FOUNDRY" -> "🌐 Foundry Agent";
+            case "AGENT" -> "AI Consistency Agent";
+            case "RULE_FALLBACK" -> "규칙 엔진 (Agent fallback)";
+            default -> "규칙 엔진";
+        };
+    }
+
+    private String evaluatorDescription(String evaluator) {
+        return switch (evaluator) {
+            case "PYTHON_EXAONE" -> "독립 Python PR Consistency Agent가 Friendli의 LG K-EXAONE으로 검토했습니다.";
+            case "PYTHON_EXAONE_FACT_GATE" -> "독립 Python Agent가 LG K-EXAONE 판단을 AST·SQL Fact Gate 원문 근거로 검증했습니다.";
+            case "SPRING_FOUNDRY" -> "Spring PR Consistency Agent가 해외 Foundry 모델로 검토했습니다.";
+            case "AGENT" -> "전용 PR Consistency Agent가 의미 단위로 검토했습니다.";
+            case "RULE_FALLBACK" -> "Agent 호출에 실패해 규칙 엔진으로 검토했습니다.";
+            default -> "규칙 엔진으로 검토했습니다.";
+        };
+    }
+
+    private String defaultReviewSummary(List<ConsistencyFinding> findings) {
+        long warnings = findings.stream().filter(finding -> "WARNING".equals(finding.severity())).count();
+        if (warnings > 0) return "명세와 구현 사이에서 병합 전 확인이 필요한 항목 " + warnings + "건을 발견했습니다.";
+        if (findings.stream().anyMatch(finding -> "INCONCLUSIVE".equals(finding.severity()))) {
+            return "확정 가능한 양쪽 근거가 부족해 정합성 판정을 보류했습니다.";
+        }
+        return "현재 PR 변경 범위에서 명세와 구현 사이의 주요 정합성 문제를 발견하지 못했습니다.";
+    }
+
+    private String oneLine(String value) {
+        if (value == null) return "";
+        return value.replace('\r', ' ').replace('\n', ' ').trim();
+    }
+
+    private String tableText(String value) {
+        return oneLine(value).replace("|", "\\|").replace("`", "'");
+    }
+
+    private String markdownText(String value) {
+        return AT_TOKEN.matcher(oneLine(value)).replaceAll("`@$1`");
+    }
+
+    private String htmlText(String value) {
+        String escaped = oneLine(value).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+        return AT_TOKEN.matcher(escaped).replaceAll("<code>@$1</code>");
+    }
+
+    private String shortSha(String sha) {
+        if (sha == null || sha.isBlank()) return "unknown";
+        return sha.substring(0, Math.min(7, sha.length()));
     }
 
     private GithubRepo findLinkedRepo(Long projectId, Long memberId, Long repoId) {
@@ -408,13 +601,28 @@ public class PullRequestConsistencyService {
     }
 
     private ProjectPullRequestResponse toResponse(GithubRepo repo, GithubPullRequestInfo pullRequest,
-                                                  List<RelatedPullRequestResponse> relatedPullRequests) {
+                                                  List<RelatedPullRequestResponse> relatedPullRequests,
+                                                  Map<String, GithubPullRequestReviewRecord> records) {
+        GithubPullRequestReviewRecord cachedRecord = records.get(reviewKey(repo.getId(), pullRequest.number()));
+        PullRequestConsistencyResult consistencyResult = Optional.ofNullable(cachedRecord)
+                .filter(record -> pullRequest.headSha() != null && pullRequest.headSha().equals(record.getHeadSha()))
+                .map(record -> new PullRequestConsistencyResult(repo.getId(), pullRequest.number(), pullRequest.headSha(),
+                        record.getScore() != null ? record.getScore() : 0, false, true,
+                        record.getReviewUrl(), record.getCheckRunUrl(),
+                        record.getEvaluator() != null ? record.getEvaluator() : "CACHED",
+                        readFindings(record.getFindingsJson())))
+                .orElse(null);
         return new ProjectPullRequestResponse(repo.getId(), repo.getFullName(), pullRequest.number(), pullRequest.title(),
                 pullRequest.body(), pullRequest.state(), pullRequest.draft(), pullRequest.headSha(), pullRequest.headRef(),
-                pullRequest.baseRef(), pullRequest.htmlUrl(), pullRequest.authorLogin(), pullRequest.updatedAt(), relatedPullRequests);
+                pullRequest.baseRef(), pullRequest.htmlUrl(), pullRequest.authorLogin(), pullRequest.updatedAt(),
+                relatedPullRequests, consistencyResult);
     }
 
-    private record AnalysisOutcome(List<ConsistencyFinding> findings, String evaluator) {}
+    private String reviewKey(Long repoId, Integer pullNumber) {
+        return repoId + ":" + pullNumber;
+    }
+
+    private record AnalysisOutcome(List<ConsistencyFinding> findings, String evaluator, String summary) {}
 
     private String normalizedAgentRuntime() {
         String normalized = agentRuntime == null ? "" : agentRuntime.trim().toUpperCase();

--- a/src/main/java/com/timiroom/domain/github/dto/ConsistencyFinding.java
+++ b/src/main/java/com/timiroom/domain/github/dto/ConsistencyFinding.java
@@ -1,8 +1,30 @@
 package com.timiroom.domain.github.dto;
 
-/** 규칙 기반 명세 대조 결과 한 건. severity는 PASS, INFO, WARNING 중 하나다. */
+import java.util.List;
+
+/** 명세 대조 결과 한 건. severity는 PASS, INFO, WARNING, INCONCLUSIVE 중 하나다. */
 public record ConsistencyFinding(
         String severity,
         String area,
-        String message
-) {}
+        String message,
+        List<String> evidence,
+        List<EvidenceReference> references,
+        String recommendation
+) {
+    public ConsistencyFinding {
+        evidence = evidence == null ? List.of() : List.copyOf(evidence);
+        references = references == null ? List.of() : List.copyOf(references);
+        if ("WARNING".equals(severity) && (recommendation == null || recommendation.isBlank())) {
+            recommendation = "명세를 기준으로 구현을 수정하거나, 구현이 의도된 변경이면 관련 명세를 함께 갱신하세요.";
+        }
+    }
+
+    public ConsistencyFinding(String severity, String area, String message) {
+        this(severity, area, message, List.of(), List.of(), null);
+    }
+
+    public ConsistencyFinding(String severity, String area, String message,
+                              List<String> evidence, String recommendation) {
+        this(severity, area, message, evidence, List.of(), recommendation);
+    }
+}

--- a/src/main/java/com/timiroom/domain/github/dto/EvidenceReference.java
+++ b/src/main/java/com/timiroom/domain/github/dto/EvidenceReference.java
@@ -1,0 +1,9 @@
+package com.timiroom.domain.github.dto;
+
+/** 명세 또는 구현 원문에서 finding을 뒷받침하는 정확한 위치. */
+public record EvidenceReference(
+        String sourceType,
+        String source,
+        Integer line,
+        String quote
+) {}

--- a/src/main/java/com/timiroom/domain/github/dto/ProjectConsistencySummary.java
+++ b/src/main/java/com/timiroom/domain/github/dto/ProjectConsistencySummary.java
@@ -12,5 +12,6 @@ public record ProjectConsistencySummary(
         String reviewUrl,
         String checkRunUrl,
         LocalDateTime checkedAt,
+        String evaluator,
         List<ConsistencyFinding> findings
 ) {}

--- a/src/main/java/com/timiroom/domain/github/dto/ProjectPullRequestResponse.java
+++ b/src/main/java/com/timiroom/domain/github/dto/ProjectPullRequestResponse.java
@@ -17,5 +17,6 @@ public record ProjectPullRequestResponse(
         String htmlUrl,
         String authorLogin,
         String updatedAt,
-        List<RelatedPullRequestResponse> relatedPullRequests
+        List<RelatedPullRequestResponse> relatedPullRequests,
+        PullRequestConsistencyResult consistencyResult
 ) {}

--- a/src/main/java/com/timiroom/domain/member/Member.java
+++ b/src/main/java/com/timiroom/domain/member/Member.java
@@ -31,6 +31,9 @@ public class Member extends BaseEntity {
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
+    @Column(name = "github_login", length = 39)
+    private String githubLogin;
+
     @Enumerated(EnumType.STRING)
     private Role role;
 
@@ -62,6 +65,10 @@ public class Member extends BaseEntity {
 
     public void updateProfileImageUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateGithubLogin(String githubLogin) {
+        this.githubLogin = githubLogin;
     }
 
     public String getDisplayName() {

--- a/src/main/java/com/timiroom/domain/member/MemberController.java
+++ b/src/main/java/com/timiroom/domain/member/MemberController.java
@@ -18,6 +18,8 @@ import java.util.Map;
 @RequestMapping("/auth")
 public class MemberController {
 
+    private static final String GITHUB_LOGIN_PATTERN = "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$";
+
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final StorageService storageService;
@@ -33,7 +35,7 @@ public class MemberController {
         return ResponseEntity.ok(memberToMap(member));
     }
 
-    /** 이름 수정 — PATCH /auth/me */
+    /** 계정 설정 수정 — PATCH /auth/me */
     @PatchMapping("/me")
     public ResponseEntity<?> updateMe(
             HttpSession session,
@@ -43,13 +45,31 @@ public class MemberController {
         if (memberId == null) {
             return ResponseEntity.status(401).body(Map.of("error", "Not logged in"));
         }
+        boolean updatesName = body.containsKey("name");
+        boolean updatesGithubLogin = body.containsKey("githubLogin");
+        if (!updatesName && !updatesGithubLogin) {
+            return ResponseEntity.badRequest().body(Map.of("error", "수정할 계정 정보를 입력해주세요"));
+        }
+
         String name = body.get("name");
-        if (name == null || name.isBlank()) {
+        if (updatesName && (name == null || name.isBlank())) {
             return ResponseEntity.badRequest().body(Map.of("error", "이름을 입력해주세요"));
         }
+
+        String githubLogin = body.get("githubLogin");
+        String normalizedGithubLogin = githubLogin == null ? null : githubLogin.trim();
+        if (updatesGithubLogin && normalizedGithubLogin != null && !normalizedGithubLogin.isBlank()
+                && !normalizedGithubLogin.matches(GITHUB_LOGIN_PATTERN)) {
+            return ResponseEntity.badRequest().body(Map.of("error", "올바른 GitHub 사용자명을 입력해주세요"));
+        }
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("Member not found"));
-        member.updateName(name);
+        if (updatesName) member.updateName(name.trim());
+        if (updatesGithubLogin) {
+            member.updateGithubLogin(normalizedGithubLogin == null || normalizedGithubLogin.isBlank()
+                    ? null : normalizedGithubLogin);
+        }
         memberRepository.save(member);
         return ResponseEntity.ok(memberToMap(member));
     }
@@ -84,6 +104,7 @@ public class MemberController {
         map.put("email", member.getEmail());
         map.put("provider", member.getProvider());
         map.put("avatarUrl", member.getProfileImageUrl());
+        map.put("githubLogin", member.getGithubLogin());
         return map;
     }
 }

--- a/src/main/java/com/timiroom/domain/team/TeamService.java
+++ b/src/main/java/com/timiroom/domain/team/TeamService.java
@@ -307,6 +307,7 @@ public class TeamService {
                             teamMember.getMemberId(),
                             member != null ? member.getDisplayName() : "알 수 없음",
                             member != null ? member.getEmail() : "",
+                            member != null ? member.getGithubLogin() : null,
                             teamMember.getTeamRole(),
                             teamMember.getJoinedAt()
                     );

--- a/src/main/java/com/timiroom/domain/team/dto/TeamMemberView.java
+++ b/src/main/java/com/timiroom/domain/team/dto/TeamMemberView.java
@@ -8,6 +8,7 @@ public record TeamMemberView(
         Long memberId,
         String memberName,
         String email,
+        String githubLogin,
         TeamRole teamRole,
         LocalDateTime joinedAt
 ) {}

--- a/src/main/java/com/timiroom/infra/github/GithubClient.java
+++ b/src/main/java/com/timiroom/infra/github/GithubClient.java
@@ -19,10 +19,17 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.web.util.UriBuilder;
 
 /**
  * GitHub REST API 클라이언트 (WebClient 기반).
@@ -33,6 +40,7 @@ import java.util.Map;
 public class GithubClient {
 
     private static final int MAX_GITHUB_RESPONSE_BYTES = 4 * 1024 * 1024;
+    private static final int MAX_SOURCE_FILE_BYTES = 192 * 1024;
 
     private final GithubAppAuthService authService;
     private final WebClient webClient;
@@ -95,8 +103,13 @@ public class GithubClient {
 
     /** 연결된 레포의 특정 브랜치 커밋 히스토리(최대 100건). */
     public List<GithubCommitInfo> listCommits(String repositoryFullName, long installationId, String branch) {
-        String encodedBranch = java.net.URLEncoder.encode(branch, java.nio.charset.StandardCharsets.UTF_8);
-        JsonNode body = get(repositoryPath(repositoryFullName) + "/commits?sha=" + encodedBranch + "&per_page=100",
+        String commitsPath = repositoryPath(repositoryFullName) + "/commits";
+        JsonNode body = get(
+                uriBuilder -> uriBuilder.path(commitsPath)
+                        .queryParam("sha", branch)
+                        .queryParam("per_page", 100)
+                        .build(),
+                commitsPath + "?sha=" + branch + "&per_page=100",
                 authService.getInstallationToken(installationId));
         List<GithubCommitInfo> result = new ArrayList<>();
         for (JsonNode node : body) {
@@ -112,9 +125,10 @@ public class GithubClient {
         return result;
     }
 
-    /** 연결 레포의 열린 이슈 목록. GitHub API가 함께 반환하는 PR 항목은 제외한다. */
+    /** 연결 레포의 전체 이슈 목록. GitHub API가 함께 반환하는 PR 항목은 제외한다. */
     public List<GithubIssueInfo> listIssues(String repositoryFullName, long installationId) {
-        JsonNode body = get(repositoryPath(repositoryFullName) + "/issues?state=open&per_page=100",
+        // 일정 진척률은 issue 종료/재오픈 상태까지 반영해야 하므로 열린 issue만 제한하지 않는다.
+        JsonNode body = get(repositoryPath(repositoryFullName) + "/issues?state=all&per_page=100",
                 authService.getInstallationToken(installationId));
         List<GithubIssueInfo> result = new ArrayList<>();
         for (JsonNode node : body) {
@@ -127,11 +141,31 @@ public class GithubClient {
     /** 연결 레포에 이슈를 생성한다. */
     public GithubIssueInfo createIssue(String repositoryFullName, long installationId,
                                        String title, String body, List<String> labels) {
+        return createIssue(repositoryFullName, installationId, title, body, labels, List.of());
+    }
+
+    /** 연결 레포에 이슈를 생성하고 등록된 GitHub 계정을 담당자로 지정한다. */
+    public GithubIssueInfo createIssue(String repositoryFullName, long installationId,
+                                       String title, String body, List<String> labels, List<String> assignees) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("title", title);
         if (body != null && !body.isBlank()) payload.put("body", body);
         if (labels != null && !labels.isEmpty()) payload.put("labels", labels);
+        if (assignees != null && !assignees.isEmpty()) payload.put("assignees", assignees);
         return toIssue(post(repositoryPath(repositoryFullName) + "/issues",
+                authService.getInstallationToken(installationId), payload));
+    }
+
+    /** 연결 레포의 기존 이슈 제목·본문·라벨·담당자를 갱신한다. null 필드는 기존 값을 유지한다. */
+    public GithubIssueInfo updateIssue(String repositoryFullName, long installationId, int issueNumber,
+                                       String title, String body, List<String> labels, List<String> assignees) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        if (title != null) payload.put("title", title);
+        if (body != null) payload.put("body", body);
+        if (labels != null) payload.put("labels", labels);
+        if (assignees != null) payload.put("assignees", assignees);
+        if (payload.isEmpty()) throw new IllegalArgumentException("수정할 GitHub Issue 정보가 없습니다");
+        return toIssue(patch(repositoryPath(repositoryFullName) + "/issues/" + issueNumber,
                 authService.getInstallationToken(installationId), payload));
     }
 
@@ -166,6 +200,38 @@ public class GithubClient {
         return result;
     }
 
+    /**
+     * 특정 ref의 UTF-8 소스 파일 원문을 읽는다. GitHub Contents API의 base64 응답만 허용하고,
+     * 너무 큰 파일·디렉터리·바이너리·없는 파일은 정합성 입력에서 안전하게 제외한다.
+     */
+    public Optional<String> getRepositoryFileContent(String repositoryFullName, long installationId,
+                                                     String filename, String ref) {
+        if (filename == null || filename.isBlank() || ref == null || ref.isBlank()) return Optional.empty();
+        String contentPath = repositoryPath(repositoryFullName) + "/contents/" + filename;
+        try {
+            JsonNode body = get(
+                    uriBuilder -> uriBuilder.path(contentPath).queryParam("ref", ref).build(),
+                    contentPath + "?ref=" + ref,
+                    authService.getInstallationToken(installationId));
+            if (!"file".equals(body.path("type").asText())
+                    || !"base64".equalsIgnoreCase(body.path("encoding").asText())
+                    || body.path("size").asInt(MAX_SOURCE_FILE_BYTES + 1) > MAX_SOURCE_FILE_BYTES) {
+                return Optional.empty();
+            }
+            byte[] decoded = Base64.getMimeDecoder().decode(body.path("content").asText(""));
+            if (decoded.length > MAX_SOURCE_FILE_BYTES || containsNullByte(decoded)) return Optional.empty();
+            return Optional.of(new String(decoded, StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.debug("GitHub 파일 원문 조회 생략 ({}@{}): {}", filename, ref, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private boolean containsNullByte(byte[] value) {
+        for (byte item : value) if (item == 0) return true;
+        return false;
+    }
+
     /** PR에 summary review comment를 게시한다. 자동 승인/변경 요청은 사용하지 않는다. */
     public GithubPullRequestReviewInfo createPullRequestCommentReview(String repositoryFullName, long installationId,
                                                                         int pullNumber, String headSha, String body) {
@@ -183,23 +249,28 @@ public class GithubClient {
 
     /** PR head commit에 완료된 정합성 check run을 게시한다. */
     public GithubCheckRunInfo createCompletedConsistencyCheckRun(String repositoryFullName, long installationId,
-                                                                  String headSha, int score, boolean hasWarnings,
-                                                                  String summary) {
+                                                                  String headSha, int score, boolean inconclusive,
+        String summary) {
         Map<String, Object> output = new LinkedHashMap<>();
-        output.put("title", "정합성 " + score + "/100");
+        output.put("title", consistencyCheckTitle(score, inconclusive));
         output.put("summary", summary);
 
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("name", "timiroom 정합성 검사");
         payload.put("head_sha", headSha);
         payload.put("status", "completed");
-        payload.put("conclusion", hasWarnings ? "neutral" : "success");
+        payload.put("conclusion", inconclusive || score < 100 ? "neutral" : "success");
         payload.put("output", output);
 
         JsonNode response = post(repositoryPath(repositoryFullName) + "/check-runs",
                 authService.getInstallationToken(installationId), payload);
         return new GithubCheckRunInfo(response.path("id").asLong(), response.path("html_url").asText(null),
                 response.path("conclusion").asText(null));
+    }
+
+    static String consistencyCheckTitle(int score, boolean inconclusive) {
+        if (inconclusive) return "판정 보류 · 근거 확인 필요";
+        return (score < 100 ? "검토 필요 · " : "정합성 확인 완료 · ") + score + "/100";
     }
 
     private GithubIssueInfo toIssue(JsonNode node) {
@@ -246,6 +317,10 @@ public class GithubClient {
         return request(HttpMethod.POST, path, bearerToken, body);
     }
 
+    private JsonNode patch(String path, String bearerToken, Object body) {
+        return request(HttpMethod.PATCH, path, bearerToken, body);
+    }
+
     private JsonNode request(HttpMethod method, String pathWithQuery, String bearerToken, Object body) {
         try {
             WebClient.RequestBodySpec request = webClient.method(method)
@@ -259,6 +334,26 @@ public class GithubClient {
                     .onStatus(HttpStatusCode::isError, r -> r.bodyToMono(String.class).defaultIfEmpty("")
                             .map(b -> new IllegalStateException(
                                     "GitHub API 호출 실패 (" + r.statusCode() + " " + pathWithQuery + "): " + b)))
+                    .bodyToMono(JsonNode.class)
+                    .block();
+        } catch (WebClientRequestException e) {
+            throw new IllegalStateException("GitHub API에 연결할 수 없습니다: " + e.getMessage(), e);
+        }
+    }
+
+    private JsonNode get(Function<UriBuilder, URI> uriFunction, String requestDescription, String bearerToken) {
+        try {
+            return webClient.get()
+                    .uri(uriFunction)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + bearerToken)
+                    .header(HttpHeaders.ACCEPT, "application/vnd.github+json")
+                    .header("X-GitHub-Api-Version", "2022-11-28")
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, response ->
+                            response.bodyToMono(String.class).defaultIfEmpty("")
+                                    .map(body -> new IllegalStateException(
+                                            "GitHub API 호출 실패 (" + response.statusCode() + " "
+                                                    + requestDescription + "): " + body)))
                     .bodyToMono(JsonNode.class)
                     .block();
         } catch (WebClientRequestException e) {

--- a/src/main/java/com/timiroom/infra/github/dto/GithubPullRequestFileInfo.java
+++ b/src/main/java/com/timiroom/infra/github/dto/GithubPullRequestFileInfo.java
@@ -6,5 +6,18 @@ public record GithubPullRequestFileInfo(
         String status,
         int additions,
         int deletions,
-        String patch
-) {}
+        String patch,
+        String content,
+        String baseContent,
+        boolean patchTruncated
+) {
+    public GithubPullRequestFileInfo(String filename, String status, int additions, int deletions, String patch) {
+        this(filename, status, additions, deletions, patch, null, null,
+                (patch == null || patch.isBlank()) && additions + deletions > 0);
+    }
+
+    public GithubPullRequestFileInfo withContents(String content, String baseContent) {
+        return new GithubPullRequestFileInfo(filename, status, additions, deletions, patch,
+                content, baseContent, patchTruncated);
+    }
+}

--- a/src/test/java/com/timiroom/domain/github/GithubIssueServiceTest.java
+++ b/src/test/java/com/timiroom/domain/github/GithubIssueServiceTest.java
@@ -1,5 +1,7 @@
 package com.timiroom.domain.github;
 
+import com.timiroom.domain.member.Member;
+import com.timiroom.domain.member.MemberRepository;
 import com.timiroom.domain.project.ProjectMember;
 import com.timiroom.domain.project.ProjectMemberRepository;
 import com.timiroom.domain.project.ProjectRole;
@@ -20,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +37,7 @@ class GithubIssueServiceTest {
     @Mock ProjectMemberRepository projectMemberRepository;
     @Mock ProjectRepoLinkRepository projectRepoLinkRepository;
     @Mock GithubRepoRepository githubRepoRepository;
+    @Mock MemberRepository memberRepository;
     @Mock GithubClient githubClient;
     @InjectMocks GithubIssueService service;
 
@@ -45,19 +49,24 @@ class GithubIssueServiceTest {
     }
 
     @Test
-    void create_PM은_연결된_레포에_GitHub_issue를_생성한다() {
+    void create_PM은_연결된_레포에_GitHub_issue를_생성하고_등록된_담당자를_지정한다() {
         givenLinkedRepo();
         when(projectMemberRepository.findByProjectIdAndMemberId(PROJECT_ID, MEMBER_ID)).thenReturn(Optional.of(
                 ProjectMember.builder().projectId(PROJECT_ID).memberId(MEMBER_ID).projectRole(ProjectRole.PM).build()));
+        Member owner = mock(Member.class);
+        when(owner.getGithubLogin()).thenReturn("Chunwol");
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(owner));
         when(githubClient.createIssue(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID), eq("로그인 오류"),
-                eq("재현 절차"), any())).thenReturn(new GithubIssueInfo(12, "로그인 오류", "재현 절차", "open",
+                eq("재현 절차"), any(), eq(List.of("Chunwol")))).thenReturn(new GithubIssueInfo(12, "로그인 오류", "재현 절차", "open",
                 "https://github.com/timiroom/timiroom-backend/issues/12", "chunwol", "2026-07-12T10:00:00Z", List.of("bug")));
 
-        var result = service.create(PROJECT_ID, MEMBER_ID, REPO_ID, "로그인 오류", "재현 절차", List.of("bug"));
+        var result = service.create(PROJECT_ID, MEMBER_ID, REPO_ID, "로그인 오류", "재현 절차", List.of("bug"), MEMBER_ID);
 
         assertThat(result.number()).isEqualTo(12);
         assertThat(result.repoFullName()).isEqualTo("timiroom/timiroom-backend");
         verify(projectService).getById(PROJECT_ID, MEMBER_ID);
+        verify(githubClient).createIssue("timiroom/timiroom-backend", INSTALLATION_ID,
+                "로그인 오류", "재현 절차", List.of("bug"), List.of("Chunwol"));
     }
 
     @Test
@@ -69,5 +78,28 @@ class GithubIssueServiceTest {
         assertThatThrownBy(() -> service.create(PROJECT_ID, MEMBER_ID, REPO_ID, "제목", "", List.of()))
                 .isInstanceOf(SecurityException.class)
                 .hasMessageContaining("PM");
+    }
+
+    @Test
+    void update_기능명세의_담당자와_일정을_GitHub_issue에_동기화한다() {
+        givenLinkedRepo();
+        when(projectMemberRepository.findByProjectIdAndMemberId(PROJECT_ID, MEMBER_ID)).thenReturn(Optional.of(
+                ProjectMember.builder().projectId(PROJECT_ID).memberId(MEMBER_ID).projectRole(ProjectRole.PM).build()));
+        Member owner = mock(Member.class);
+        when(owner.getGithubLogin()).thenReturn("Chunwol");
+        when(memberRepository.findById(MEMBER_ID)).thenReturn(Optional.of(owner));
+        when(githubClient.updateIssue("timiroom/timiroom-backend", INSTALLATION_ID, 12,
+                "[백엔드] 로그인", "담당자: 임석현\n종료일: 2026-08-01", null, List.of("Chunwol")))
+                .thenReturn(new GithubIssueInfo(12, "[백엔드] 로그인", "담당자: 임석현\n종료일: 2026-08-01",
+                        "open", "https://github.com/timiroom/timiroom-backend/issues/12", "chunwol",
+                        "2026-07-12T10:00:00Z", List.of("feature")));
+
+        var result = service.update(PROJECT_ID, MEMBER_ID, REPO_ID, 12,
+                "[백엔드] 로그인", "담당자: 임석현\n종료일: 2026-08-01", null, MEMBER_ID);
+
+        assertThat(result.number()).isEqualTo(12);
+        assertThat(result.body()).contains("2026-08-01");
+        verify(githubClient).updateIssue("timiroom/timiroom-backend", INSTALLATION_ID, 12,
+                "[백엔드] 로그인", "담당자: 임석현\n종료일: 2026-08-01", null, List.of("Chunwol"));
     }
 }

--- a/src/test/java/com/timiroom/domain/github/PullRequestConsistencyServiceTest.java
+++ b/src/test/java/com/timiroom/domain/github/PullRequestConsistencyServiceTest.java
@@ -101,7 +101,11 @@ class PullRequestConsistencyServiceTest {
         ArgumentCaptor<String> reviewBody = ArgumentCaptor.forClass(String.class);
         verify(githubClient).createPullRequestCommentReview(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
                 eq(42), eq("head-sha"), reviewBody.capture());
-        assertThat(reviewBody.getValue()).contains("정합성 자동 리뷰").contains("100/100");
+        assertThat(reviewBody.getValue())
+                .contains("timiroom PR 정합성 리뷰")
+                .contains("리뷰 요약")
+                .contains("정합성 점수")
+                .contains("100/100");
         verify(reviewRecordRepository).save(any(GithubPullRequestReviewRecord.class));
     }
 
@@ -110,12 +114,14 @@ class PullRequestConsistencyServiceTest {
         givenLinkedPm();
         when(reviewRecordRepository.findByProjectIdAndGithubRepoIdAndPullNumber(PROJECT_ID, REPO_ID, 42))
                 .thenReturn(Optional.of(GithubPullRequestReviewRecord.builder().projectId(PROJECT_ID)
-                        .githubRepoId(REPO_ID).pullNumber(42).headSha("head-sha").reviewUrl("https://review").build()));
+                        .githubRepoId(REPO_ID).pullNumber(42).headSha("head-sha").reviewUrl("https://review")
+                        .evaluator("PYTHON_EXAONE").build()));
 
         var result = service.checkAndReview(PROJECT_ID, MEMBER_ID, REPO_ID, 42);
 
         assertThat(result.skippedDuplicate()).isTrue();
         assertThat(result.reviewPosted()).isFalse();
+        assertThat(result.evaluator()).isEqualTo("PYTHON_EXAONE");
         verify(githubClient, never()).createPullRequestCommentReview(any(), anyLong(), anyInt(), any(), any());
     }
 
@@ -164,8 +170,11 @@ class PullRequestConsistencyServiceTest {
         when(reviewRecordRepository.findByProjectIdAndGithubRepoIdAndPullNumber(PROJECT_ID, REPO_ID, 42))
                 .thenReturn(Optional.empty());
         var agentResponse = new ObjectMapper().readTree("""
-                {"agent":"PR_CONSISTENCY_AGENT","provider":"EXAONE","findings":[
-                  {"severity":"PASS","area":"API","message":"EXAONE 검증 결과 API_SPEC과 일치합니다."}
+                {"agent":"PR_CONSISTENCY_AGENT","provider":"EXAONE","evaluationMode":"EXAONE_FACT_GATE","summary":"API 명세와 구현이 일치합니다.","findings":[
+                  {"severity":"PASS","area":"API","message":"@GetMapping EXAONE 검증 결과 API_SPEC과 일치합니다.",
+                   "evidence":["@GetMapping으로 GET /api/v1/tasks 구현"],
+                   "references":[{"sourceType":"IMPLEMENTATION","source":"TaskController.java","line":12,"quote":"@GetMapping('/api/v1/tasks')"}],
+                   "recommendation":"현재 구현을 유지하세요."}
                 ]}
                 """);
         when(consistencyServiceClient.reviewPullRequestConsistency(any())).thenReturn(agentResponse);
@@ -176,11 +185,83 @@ class PullRequestConsistencyServiceTest {
 
         var result = service.checkAndReview(PROJECT_ID, MEMBER_ID, REPO_ID, 42);
 
-        assertThat(result.evaluator()).isEqualTo("PYTHON_EXAONE");
+        assertThat(result.evaluator()).isEqualTo("PYTHON_EXAONE_FACT_GATE");
         assertThat(result.findings()).extracting(finding -> finding.message())
-                .containsExactly("EXAONE 검증 결과 API_SPEC과 일치합니다.");
+                .containsExactly("@GetMapping EXAONE 검증 결과 API_SPEC과 일치합니다.");
+        assertThat(result.findings().getFirst().evidence()).containsExactly("@GetMapping으로 GET /api/v1/tasks 구현");
+        assertThat(result.findings().getFirst().recommendation()).isEqualTo("현재 구현을 유지하세요.");
+        assertThat(result.findings().getFirst().references()).hasSize(1);
+        assertThat(result.findings().getFirst().references().getFirst().line()).isEqualTo(12);
+        ArgumentCaptor<String> reviewBody = ArgumentCaptor.forClass(String.class);
+        verify(githubClient).createPullRequestCommentReview(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
+                eq(42), eq("head-sha"), reviewBody.capture());
+        assertThat(reviewBody.getValue()).contains("`@GetMapping` EXAONE 검증 결과 API_SPEC과 일치합니다.");
         verify(consistencyServiceClient).reviewPullRequestConsistency(any());
         verify(ragPipelineClient, never()).reviewPullRequestConsistency(any());
+    }
+
+    @Test
+    void checkAndReview_Python_분석요청에_head와_base_전체파일을_제한적으로_포함한다() throws Exception {
+        givenLinkedPm();
+        ReflectionTestUtils.setField(service, "agentEnabled", true);
+        ReflectionTestUtils.setField(service, "agentRuntime", "PYTHON");
+        when(pipelineService.getLatestArtifactsByProject(PROJECT_ID)).thenReturn(List.of(
+                PipelineArtifact.builder().artifactType(PipelineArtifact.ArtifactType.API_SPEC)
+                        .content("GET /api/v1/tasks").build()));
+        when(reviewRecordRepository.findByProjectIdAndGithubRepoIdAndPullNumber(PROJECT_ID, REPO_ID, 42))
+                .thenReturn(Optional.empty());
+        when(githubClient.getRepositoryFileContent("timiroom/timiroom-backend", INSTALLATION_ID,
+                "TaskController.java", "head-sha")).thenReturn(Optional.of("head source"));
+        when(githubClient.getRepositoryFileContent("timiroom/timiroom-backend", INSTALLATION_ID,
+                "TaskController.java", "develop")).thenReturn(Optional.of("base source"));
+        when(consistencyServiceClient.reviewPullRequestConsistency(any())).thenReturn(new ObjectMapper().readTree("""
+                {"evaluationMode":"EXAONE_FACT_GATE","summary":"일치","findings":[
+                  {"severity":"PASS","area":"API","message":"일치","evidence":[]}
+                ]}
+                """));
+        when(githubClient.createCompletedConsistencyCheckRun(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
+                eq("head-sha"), eq(100), eq(false), any())).thenReturn(new GithubCheckRunInfo(9L, "https://check", "success"));
+        when(githubClient.createPullRequestCommentReview(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
+                eq(42), eq("head-sha"), any())).thenReturn(new GithubPullRequestReviewInfo(7L, "https://review", "COMMENTED"));
+
+        service.checkAndReview(PROJECT_ID, MEMBER_ID, REPO_ID, 42);
+
+        ArgumentCaptor<Object> request = ArgumentCaptor.forClass(Object.class);
+        verify(consistencyServiceClient).reviewPullRequestConsistency(request.capture());
+        var changedFiles = (List<?>) ((Map<?, ?>) request.getValue()).get("changedFiles");
+        var changedFile = (Map<?, ?>) changedFiles.getFirst();
+        assertThat(changedFile.get("content")).isEqualTo("head source");
+        assertThat(changedFile.get("baseContent")).isEqualTo("base source");
+        assertThat(changedFile.get("patchTruncated")).isEqualTo(false);
+    }
+
+    @Test
+    void checkAndReview_근거부족은_통과가_아니라_판정보류_0점이다() throws Exception {
+        givenLinkedPm();
+        ReflectionTestUtils.setField(service, "agentEnabled", true);
+        ReflectionTestUtils.setField(service, "agentRuntime", "PYTHON");
+        when(pipelineService.getLatestArtifactsByProject(PROJECT_ID)).thenReturn(List.of());
+        when(reviewRecordRepository.findByProjectIdAndGithubRepoIdAndPullNumber(PROJECT_ID, REPO_ID, 42))
+                .thenReturn(Optional.empty());
+        when(consistencyServiceClient.reviewPullRequestConsistency(any())).thenReturn(new ObjectMapper().readTree("""
+                {"evaluationMode":"EXAONE_FACT_GATE","summary":"판정 보류","findings":[
+                  {"severity":"INCONCLUSIVE","area":"Fact Gate","message":"근거 부족","evidence":[]}
+                ]}
+                """));
+        when(githubClient.createCompletedConsistencyCheckRun(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
+                eq("head-sha"), eq(0), eq(true), any())).thenReturn(new GithubCheckRunInfo(9L, "https://check", "neutral"));
+        when(githubClient.createPullRequestCommentReview(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
+                eq(42), eq("head-sha"), any())).thenReturn(new GithubPullRequestReviewInfo(7L, "https://review", "COMMENTED"));
+        when(projectMemberRepository.findByProjectId(PROJECT_ID)).thenReturn(List.of());
+
+        var result = service.checkAndReview(PROJECT_ID, MEMBER_ID, REPO_ID, 42);
+
+        assertThat(result.score()).isZero();
+        assertThat(result.findings().getFirst().severity()).isEqualTo("INCONCLUSIVE");
+        ArgumentCaptor<String> reviewBody = ArgumentCaptor.forClass(String.class);
+        verify(githubClient).createPullRequestCommentReview(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
+                eq(42), eq("head-sha"), reviewBody.capture());
+        assertThat(reviewBody.getValue()).contains("판정 보류").contains("**—**");
     }
 
     @Test
@@ -213,7 +294,7 @@ class PullRequestConsistencyServiceTest {
         when(reviewRecordRepository.findByProjectIdAndGithubRepoIdAndPullNumber(PROJECT_ID, REPO_ID, 42))
                 .thenReturn(Optional.empty());
         when(githubClient.createCompletedConsistencyCheckRun(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
-                eq("head-sha"), eq(75), eq(true), any())).thenReturn(new GithubCheckRunInfo(9L, "https://check", "neutral"));
+                eq("head-sha"), eq(75), eq(false), any())).thenReturn(new GithubCheckRunInfo(9L, "https://check", "neutral"));
         when(githubClient.createPullRequestCommentReview(eq("timiroom/timiroom-backend"), eq(INSTALLATION_ID),
                 eq(42), eq("head-sha"), any())).thenReturn(new GithubPullRequestReviewInfo(7L, "https://review", "COMMENTED"));
         when(projectMemberRepository.findByProjectId(PROJECT_ID)).thenReturn(List.of(
@@ -302,5 +383,31 @@ class PullRequestConsistencyServiceTest {
         assertThat(pulls).hasSize(2);
         assertThat(pulls.stream().filter(pull -> pull.repoId().equals(REPO_ID)).findFirst().orElseThrow().relatedPullRequests())
                 .extracting(related -> related.repoFullName()).containsExactly("timiroom/timiroom-frontend");
+    }
+
+    @Test
+    void list_같은_head_sha의_기존_정합성_결과를_함께_반환한다() {
+        when(projectRepoLinkRepository.findByProjectId(PROJECT_ID)).thenReturn(List.of(
+                ProjectRepoLink.builder().projectId(PROJECT_ID).githubRepoId(REPO_ID).build()));
+        when(githubRepoRepository.findById(REPO_ID)).thenReturn(Optional.of(GithubRepo.builder().id(REPO_ID)
+                .fullName("timiroom/timiroom-backend").installationId(INSTALLATION_ID).build()));
+        when(githubClient.listPullRequests("timiroom/timiroom-backend", INSTALLATION_ID)).thenReturn(List.of(
+                new GithubPullRequestInfo(42, "feat: login #24", "", "open", false, "sha1", "feature/24-login",
+                        "develop", "https://backend/pr/42", "dev", "2026-07-12T10:00:00Z")));
+        when(reviewRecordRepository.findByProjectIdAndGithubRepoIdIn(PROJECT_ID, List.of(REPO_ID)))
+                .thenReturn(List.of(GithubPullRequestReviewRecord.builder()
+                        .projectId(PROJECT_ID).githubRepoId(REPO_ID).pullNumber(42).headSha("sha1")
+                        .reviewUrl("https://review").checkRunUrl("https://check").score(75)
+                        .evaluator("PYTHON_EXAONE_FACT_GATE")
+                        .findingsJson("[{\"severity\":\"WARNING\",\"area\":\"API\",\"message\":\"메서드 불일치\"}]")
+                        .build()));
+
+        var pulls = service.list(PROJECT_ID, MEMBER_ID);
+
+        assertThat(pulls).hasSize(1);
+        assertThat(pulls.getFirst().consistencyResult()).isNotNull();
+        assertThat(pulls.getFirst().consistencyResult().score()).isEqualTo(75);
+        assertThat(pulls.getFirst().consistencyResult().evaluator()).isEqualTo("PYTHON_EXAONE_FACT_GATE");
+        assertThat(pulls.getFirst().consistencyResult().findings()).hasSize(1);
     }
 }

--- a/src/test/java/com/timiroom/infra/github/GithubClientTest.java
+++ b/src/test/java/com/timiroom/infra/github/GithubClientTest.java
@@ -1,0 +1,20 @@
+package com.timiroom.infra.github;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GithubClientTest {
+
+    @Test
+    void score가_0이어도_확정경고면_판정보류가_아니다() {
+        assertThat(GithubClient.consistencyCheckTitle(0, false))
+                .isEqualTo("검토 필요 · 0/100");
+    }
+
+    @Test
+    void 근거부족일_때만_판정보류로_표시한다() {
+        assertThat(GithubClient.consistencyCheckTitle(0, true))
+                .isEqualTo("판정 보류 · 근거 확인 필요");
+    }
+}


### PR DESCRIPTION
## 변경 내용
- Python EXAONE Agent를 기본 PR 정합성 실행기로 연결하고 규칙 기반 fallback을 유지합니다.
- PR head/base 원문을 함께 전달해 변경분만 Fact Gate가 검증하도록 합니다.
- 근거 파일·라인·인용과 evaluator를 저장하고 프로젝트 단위 결과에 노출합니다.
- 경고 0점과 근거 부족(INCONCLUSIVE)의 Check Run 표시를 분리합니다.
- 기능명세서에서 생성한 GitHub Issue의 제목·본문·담당자·일정을 동기화하는 PATCH API를 추가합니다.
- 팀원의 등록된 GitHub login을 Issue assignee에 연결합니다.

## 검증
- `./gradlew test` (BUILD SUCCESSFUL)
- 로컬 백엔드/정합성 서비스 연동 및 health check 200
- Python EXAONE Fact Gate 실호출 검증 완료