### PR TITLE
feat: API 명세 기반 Mock 서버 추가

### DIFF
--- a/src/main/java/com/timiroom/config/SecurityConfig.java
+++ b/src/main/java/com/timiroom/config/SecurityConfig.java
@@ -47,6 +47,9 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**", "/oauth2/**", "/login/**", "/error").permitAll()
                         .requestMatchers("/api/v1/teams/invite/**").permitAll()
                         .requestMatchers("/webhooks/github").permitAll()
+                        // Mock 서버는 프론트/외부 도구(Postman 등)가 직접 호출하므로 인증 제외
+                        // (호출 로그 조회 /api/v1/mock/** 은 인증 필요)
+                        .requestMatchers("/mock/**").permitAll()
                         .requestMatchers("/api/v1/pipeline/**").authenticated()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/timiroom/domain/mock/controller/MockController.java
+++ b/src/main/java/com/timiroom/domain/mock/controller/MockController.java
@@ -1,0 +1,131 @@
+package com.timiroom.domain.mock.controller;
+
+import com.timiroom.domain.mock.entity.MockApiLog;
+import com.timiroom.domain.mock.service.MockService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Mock 서버 엔드포인트
+ *
+ * 파이프라인이 만든 API 명세를 실제로 호출 가능한 가상 API로 노출한다.
+ * 프론트엔드는 백엔드 구현 완료를 기다리지 않고 이 URL로 개발을 시작할 수 있다.
+ *
+ *   호출:  {METHOD} /mock/{projectId}/api/v1/users/3
+ *   목록:  GET      /mock/{projectId}/_endpoints
+ *   로그:  GET      /api/v1/mock/{projectId}/logs   (인증 필요)
+ *
+ * 지원 헤더:
+ *   X-Mock-Delay : 지정한 밀리초만큼 응답을 지연 (네트워크 지연 시뮬레이션)
+ *   X-Mock-Error : 지정한 상태 코드로 강제 에러 응답 (에러 처리 테스트)
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class MockController {
+
+    /** 의도치 않은 장시간 블로킹을 막기 위한 지연 상한 */
+    private static final long MAX_MOCK_DELAY_MS = 10_000L;
+
+    private final MockService mockService;
+
+    /** 이 프로젝트에서 호출 가능한 Mock 엔드포인트 목록 */
+    @GetMapping("/mock/{projectId}/_endpoints")
+    public ResponseEntity<Map<String, Object>> endpoints(@PathVariable Long projectId) {
+        List<Map<String, Object>> list = mockService.listMockEndpoints(projectId);
+        return ResponseEntity.ok(Map.of(
+                "projectId", projectId,
+                "baseUrl", "/mock/" + projectId,
+                "count", list.size(),
+                "endpoints", list
+        ));
+    }
+
+    /** Mock 요청 처리 — 모든 메서드/경로를 받는다 */
+    @RequestMapping("/mock/{projectId}/**")
+    public ResponseEntity<Map<String, Object>> handle(@PathVariable Long projectId,
+                                                     HttpServletRequest request) {
+        long startedAt = System.currentTimeMillis();
+        String method = request.getMethod();
+        String endpoint = extractEndpoint(request, projectId);
+
+        Integer forcedStatus = parseIntHeader(request.getHeader("X-Mock-Error"));
+        MockService.MockResult result = mockService.handle(projectId, method, endpoint, forcedStatus);
+
+        applyDelay(request.getHeader("X-Mock-Delay"));
+
+        long latency = System.currentTimeMillis() - startedAt;
+        mockService.log(projectId, method, endpoint, result.statusCode(), latency, result.matchedPath());
+
+        log.debug("Mock 요청 | {} {} → {} ({}ms, 매칭: {})",
+                method, endpoint, result.statusCode(), latency, result.matchedPath());
+
+        return ResponseEntity.status(result.statusCode())
+                .header("X-Mock-Server", "timiroom")
+                .header("X-Mock-Matched-Path", result.matchedPath() == null ? "none" : result.matchedPath())
+                .body(result.body());
+    }
+
+    /** Mock 호출 로그 조회 (팀원이 대시보드에서 확인) */
+    @GetMapping("/api/v1/mock/{projectId}/logs")
+    public ResponseEntity<List<MockApiLog>> logs(@PathVariable Long projectId,
+                                                 @RequestParam(defaultValue = "50") int limit) {
+        int capped = Math.min(Math.max(limit, 1), 200);
+        return ResponseEntity.ok(mockService.getLogs(projectId, PageRequest.of(0, capped)));
+    }
+
+    /**
+     * 요청 URI에서 /mock/{projectId} 프리픽스를 떼어 실제 명세 경로만 남긴다.
+     * 예) /mock/7/api/v1/users/3 → /api/v1/users/3
+     */
+    private String extractEndpoint(HttpServletRequest request, Long projectId) {
+        String fullPath = (String) request.getAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE);
+        if (fullPath == null || fullPath.isBlank()) {
+            fullPath = request.getRequestURI();
+        }
+
+        String prefix = "/mock/" + projectId;
+        String endpoint = fullPath.startsWith(prefix) ? fullPath.substring(prefix.length()) : fullPath;
+        return endpoint.isBlank() ? "/" : endpoint;
+    }
+
+    private Integer parseIntHeader(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            int value = Integer.parseInt(raw.trim());
+            return (value >= 100 && value <= 599) ? value : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private void applyDelay(String rawDelay) {
+        Integer requested = parseNonNegativeInt(rawDelay);
+        if (requested == null || requested == 0) return;
+
+        long delay = Math.min(requested, MAX_MOCK_DELAY_MS);
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private Integer parseNonNegativeInt(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            int value = Integer.parseInt(raw.trim());
+            return value >= 0 ? value : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/timiroom/domain/mock/entity/MockApiLog.java
+++ b/src/main/java/com/timiroom/domain/mock/entity/MockApiLog.java
@@ -1,0 +1,52 @@
+package com.timiroom.domain.mock.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * Mock API 호출 로그
+ *
+ * Mock 서버로 들어온 요청 1건의 기록.
+ * 프론트엔드 개발자가 어떤 엔드포인트를 얼마나 호출했는지 추적하는 용도.
+ */
+@Entity
+@Table(name = "mock_api_log", indexes = {
+        @Index(name = "idx_mock_log_project", columnList = "project_id, created_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MockApiLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long logId;
+
+    @Column(name = "project_id", nullable = false)
+    private Long projectId;
+
+    @Column(nullable = false, length = 10)
+    private String method;
+
+    @Column(nullable = false, length = 500)
+    private String endpoint;
+
+    @Column(name = "status_code", nullable = false)
+    private int statusCode;
+
+    @Column(name = "latency_ms", nullable = false)
+    private long latencyMs;
+
+    /** 매칭된 명세의 path 템플릿 (예: /api/v1/users/{id}). 매칭 실패 시 null */
+    @Column(name = "matched_path", length = 500)
+    private String matchedPath;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/timiroom/domain/mock/repository/MockApiLogRepository.java
+++ b/src/main/java/com/timiroom/domain/mock/repository/MockApiLogRepository.java
@@ -1,0 +1,11 @@
+package com.timiroom.domain.mock.repository;
+
+import com.timiroom.domain.mock.entity.MockApiLog;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MockApiLogRepository extends JpaRepository<MockApiLog, Long> {
+    List<MockApiLog> findByProjectIdOrderByCreatedAtDesc(Long projectId, Pageable pageable);
+}

--- a/src/main/java/com/timiroom/domain/mock/service/MockService.java
+++ b/src/main/java/com/timiroom/domain/mock/service/MockService.java
@@ -1,0 +1,282 @@
+package com.timiroom.domain.mock.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.timiroom.domain.mock.entity.MockApiLog;
+import com.timiroom.domain.mock.repository.MockApiLogRepository;
+import com.timiroom.domain.pipeline.entity.PipelineArtifact;
+import com.timiroom.domain.pipeline.service.PipelineService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Mock 서버 — 파이프라인이 생성한 API 명세를 실제 호출 가능한 가상 엔드포인트로 제공
+ *
+ * 동작:
+ *   1. projectId로 최신 API_SPEC 아티팩트를 조회
+ *   2. 요청 method + path를 명세의 엔드포인트와 매칭 (path 템플릿 {id} 지원)
+ *   3. 매칭된 엔드포인트의 successResponse 스키마로 가짜 응답 생성
+ *
+ * 백엔드 구현이 끝나기 전에 프론트엔드가 개발을 시작할 수 있게 하는 것이 목적.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MockService {
+
+    private final PipelineService pipelineService;
+    private final MockApiLogRepository logRepository;
+    private final ObjectMapper objectMapper;
+
+    /** 필드 타입 문자열에서 주석(" // 설명")을 떼어낸다 */
+    private static final Pattern TYPE_COMMENT = Pattern.compile("\\s*//.*$");
+
+    /** path 템플릿의 {param} 부분 */
+    private static final Pattern PATH_VARIABLE = Pattern.compile("\\{[^/}]+}");
+
+    /**
+     * Mock 요청 처리 결과
+     *
+     * @param statusCode  응답 상태 코드
+     * @param body        응답 본문
+     * @param matchedPath 매칭된 명세의 path 템플릿 (실패 시 null)
+     */
+    public record MockResult(int statusCode, Map<String, Object> body, String matchedPath) {}
+
+    /**
+     * 요청을 명세와 매칭해 가짜 응답을 만든다.
+     *
+     * @param projectId    프로젝트 ID
+     * @param method       HTTP 메서드
+     * @param endpoint     요청 경로 (mock 프리픽스가 제거된 상태, 예: /api/v1/users/3)
+     * @param forcedStatus X-Mock-Error 헤더로 지정된 강제 상태 코드 (없으면 null)
+     */
+    public MockResult handle(Long projectId, String method, String endpoint, Integer forcedStatus) {
+        Optional<JsonNode> matched = findEndpoint(projectId, method, endpoint);
+
+        if (matched.isEmpty()) {
+            return new MockResult(404, Map.of(
+                    "error", "Mock API Not Found",
+                    "message", "프로젝트 " + projectId + "의 API 명세에 "
+                            + method + " " + endpoint + " 와 일치하는 엔드포인트가 없습니다."
+            ), null);
+        }
+
+        JsonNode spec = matched.get();
+        String matchedPath = spec.path("path").asText("");
+
+        // X-Mock-Error로 강제 에러를 요청한 경우, 명세는 매칭됐지만 에러를 반환
+        if (forcedStatus != null) {
+            return new MockResult(forcedStatus, Map.of(
+                    "status", forcedStatus,
+                    "error", "Forced Error",
+                    "message", "X-Mock-Error 헤더로 요청된 강제 " + forcedStatus + " 응답입니다."
+            ), matchedPath);
+        }
+
+        Map<String, Object> body = buildResponseBody(spec.path("successResponse"));
+        int status = "POST".equalsIgnoreCase(method) ? 201 : 200;
+        return new MockResult(status, body, matchedPath);
+    }
+
+    /** 호출 로그 저장 — 실패해도 Mock 응답 자체를 막지 않는다 */
+    @Transactional
+    public void log(Long projectId, String method, String endpoint,
+                    int statusCode, long latencyMs, String matchedPath) {
+        try {
+            logRepository.save(MockApiLog.builder()
+                    .projectId(projectId)
+                    .method(method)
+                    .endpoint(truncate(endpoint, 500))
+                    .statusCode(statusCode)
+                    .latencyMs(latencyMs)
+                    .matchedPath(truncate(matchedPath, 500))
+                    .build());
+        } catch (Exception e) {
+            log.warn("Mock 호출 로그 저장 실패 | projectId: {}, error: {}", projectId, e.getMessage());
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<MockApiLog> getLogs(Long projectId, org.springframework.data.domain.Pageable pageable) {
+        return logRepository.findByProjectIdOrderByCreatedAtDesc(projectId, pageable);
+    }
+
+    /** 프로젝트의 최신 API_SPEC 아티팩트에서 method + path가 맞는 엔드포인트를 찾는다 */
+    private Optional<JsonNode> findEndpoint(Long projectId, String method, String endpoint) {
+        String specJson = pipelineService.getLatestArtifactsByProject(projectId).stream()
+                .filter(a -> a.getArtifactType() == PipelineArtifact.ArtifactType.API_SPEC)
+                .map(PipelineArtifact::getContent)
+                .findFirst()
+                .orElse(null);
+
+        if (specJson == null || specJson.isBlank()) {
+            log.debug("API_SPEC 아티팩트 없음 | projectId: {}", projectId);
+            return Optional.empty();
+        }
+
+        JsonNode endpoints;
+        try {
+            endpoints = objectMapper.readTree(specJson).path("endpoints");
+        } catch (Exception e) {
+            log.warn("API_SPEC 파싱 실패 | projectId: {}, error: {}", projectId, e.getMessage());
+            return Optional.empty();
+        }
+        if (!endpoints.isArray()) return Optional.empty();
+
+        JsonNode exactMatch = null;
+        JsonNode templateMatch = null;
+
+        for (JsonNode ep : endpoints) {
+            if (!method.equalsIgnoreCase(ep.path("method").asText())) continue;
+
+            String specPath = ep.path("path").asText("");
+            if (specPath.isBlank()) continue;
+
+            if (specPath.equals(endpoint)) {
+                exactMatch = ep;          // 정확히 일치하면 최우선
+                break;
+            }
+            if (templateMatch == null && matchesTemplate(specPath, endpoint)) {
+                templateMatch = ep;       // {id} 같은 변수를 포함한 매칭은 후순위
+            }
+        }
+
+        return Optional.ofNullable(exactMatch != null ? exactMatch : templateMatch);
+    }
+
+    /** /api/v1/users/{id} 형태의 템플릿이 실제 경로와 맞는지 검사 */
+    private boolean matchesTemplate(String specPath, String requestPath) {
+        if (!specPath.contains("{")) return false;
+
+        StringBuilder regex = new StringBuilder("^");
+        Matcher m = PATH_VARIABLE.matcher(specPath);
+        int last = 0;
+        while (m.find()) {
+            regex.append(Pattern.quote(specPath.substring(last, m.start())));
+            regex.append("[^/]+");
+            last = m.end();
+        }
+        regex.append(Pattern.quote(specPath.substring(last))).append("$");
+
+        return requestPath.matches(regex.toString());
+    }
+
+    /**
+     * successResponse 스키마로 가짜 응답 본문을 만든다.
+     *
+     * 명세의 값은 "integer // 사용자 ID" 처럼 타입과 주석이 섞여 있어 타입만 추출해 쓴다.
+     * 중첩 객체/배열은 재귀적으로 처리한다.
+     */
+    private Map<String, Object> buildResponseBody(JsonNode schema) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        if (schema == null || schema.isMissingNode() || schema.isNull()) return body;
+
+        // 명세가 문자열 하나로 뭉개져 있는 경우
+        if (!schema.isObject()) {
+            body.put("result", sampleValue("result", schema.asText("string")));
+            return body;
+        }
+
+        for (Map.Entry<String, JsonNode> entry : schema.properties()) {
+            String name = entry.getKey();
+            JsonNode value = entry.getValue();
+
+            if (value.isObject()) {
+                body.put(name, buildResponseBody(value));
+            } else if (value.isArray()) {
+                List<Object> arr = new ArrayList<>();
+                if (!value.isEmpty()) {
+                    JsonNode first = value.get(0);
+                    arr.add(first.isObject() ? buildResponseBody(first)
+                                             : sampleValue(name, first.asText("string")));
+                }
+                body.put(name, arr);
+            } else {
+                body.put(name, sampleValue(name, value.asText("string")));
+            }
+        }
+
+        return body;
+    }
+
+    /**
+     * 필드명과 타입으로 그럴듯한 샘플 값을 만든다.
+     * 타입이 우선이고, string인 경우 필드명으로 값을 좀 더 현실적으로 고른다.
+     */
+    private Object sampleValue(String fieldName, String rawType) {
+        String type = TYPE_COMMENT.matcher(rawType == null ? "" : rawType).replaceAll("").trim().toLowerCase();
+        String name = fieldName == null ? "" : fieldName.toLowerCase();
+
+        if (type.startsWith("bool")) return true;
+        if (type.startsWith("int") || type.startsWith("long")) return name.endsWith("id") ? 1 : 123;
+        if (type.startsWith("number") || type.startsWith("float") || type.startsWith("double")) return 1234.56;
+        if (type.startsWith("array") || type.startsWith("list")) return List.of();
+        if (type.startsWith("object") || type.startsWith("map")) return Map.of();
+
+        // 문자열 계열 — 필드명으로 현실적인 값 선택
+        if (name.contains("email")) return "sample@timiroom.dev";
+        if (name.contains("password")) return "********";
+        if (name.contains("phone") || name.contains("tel")) return "010-1234-5678";
+        if (name.contains("url") || name.contains("link") || name.contains("image")) return "https://cdn.timiroom.dev/sample.png";
+        if (name.contains("token")) return "mock.jwt.token";
+        if (name.contains("date") || name.contains("time") || name.endsWith("at")) return "2026-01-01T00:00:00";
+        if (name.contains("status")) return "ACTIVE";
+        if (name.contains("uuid")) return "00000000-0000-0000-0000-000000000000";
+        if (name.contains("name") || name.contains("title")) return "샘플 " + fieldName;
+
+        if (type.startsWith("date") || type.startsWith("timestamp")) return "2026-01-01T00:00:00";
+        if (type.startsWith("uuid")) return "00000000-0000-0000-0000-000000000000";
+
+        return "sample_" + fieldName;
+    }
+
+    private String truncate(String s, int max) {
+        if (s == null) return null;
+        return s.length() <= max ? s : s.substring(0, max);
+    }
+
+    /** 명세에 정의된 엔드포인트 목록을 요약해 돌려준다 (Mock 서버 안내용) */
+    @Transactional(readOnly = true)
+    public List<Map<String, Object>> listMockEndpoints(Long projectId) {
+        String specJson = pipelineService.getLatestArtifactsByProject(projectId).stream()
+                .filter(a -> a.getArtifactType() == PipelineArtifact.ArtifactType.API_SPEC)
+                .map(PipelineArtifact::getContent)
+                .findFirst()
+                .orElse(null);
+
+        if (specJson == null || specJson.isBlank()) return List.of();
+
+        try {
+            JsonNode endpoints = objectMapper.readTree(specJson).path("endpoints");
+            if (!endpoints.isArray()) return List.of();
+
+            List<Map<String, Object>> result = new ArrayList<>();
+            for (JsonNode ep : endpoints) {
+                result.add(objectMapper.convertValue(
+                        Map.of(
+                                "method", ep.path("method").asText(""),
+                                "path", ep.path("path").asText(""),
+                                "description", ep.path("description").asText(""),
+                                "authRequired", ep.path("authRequired").asBoolean(false)
+                        ),
+                        new TypeReference<Map<String, Object>>() {}));
+            }
+            return result;
+        } catch (Exception e) {
+            log.warn("Mock 엔드포인트 목록 조회 실패 | projectId: {}", projectId, e);
+            return List.of();
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 파이프라인이 만든 API 명세(`pipeline_artifact`의 `API_SPEC`)를 실제 호출 가능한 Mock 서버로 노출
  - `GET /mock/{projectId}/_endpoints` — 호출 가능한 엔드포인트 목록
  - `ANY /mock/{projectId}/**` — 명세 기반 가짜 응답
  - `GET /api/v1/mock/{projectId}/logs` — 호출 로그 (인증 필요)
- path 템플릿 매칭 지원 (`/api/v1/reviews/{id}`), 정확 일치를 우선
- 중첩 객체·배열까지 재귀적으로 응답 생성
- `X-Mock-Delay`(응답 지연, 상한 10초), `X-Mock-Error`(강제 에러) 헤더로 로딩·에러 UI 테스트 지원
- 호출 로그를 `mock_api_log`에 기록하며 매칭된 명세 경로를 함께 남김
- `/mock/**` 은 Postman 등 외부 도구가 직접 호출하므로 인증 제외 (로그 조회는 인증 유지)

기존 `pipeline_artifact`를 읽으므로 **새 테이블·마이그레이션 없음**. 백엔드 구현 완료 전에 프론트가 개발을 시작할 수 있게 하는 것이 목적입니다.

## 검증

- `gradlew build` / `gradlew test` 성공
- Mock API 런타임 8종 통과 — 엔드포인트 인식 3개, GET 200, `{reviewId}` 템플릿 매칭 200, POST 201, 강제 에러 503, 지연 2.05초, 없는 경로 404, 매칭 경로 헤더
- 호출 로그 8건 `matched_path` 정확 기록
- `mock_api_log` DROP 후 재기동 → 인덱스까지 정상 재생성 (Flyway 공존 확인, 팀원은 pull 후 별도 조치 불필요)

<details>
<summary>사용 예시</summary>

```bash
# 어떤 엔드포인트가 있는지
curl http://localhost:8080/mock/1/_endpoints

# 실제 호출 — 명세의 successResponse 형태로 응답
curl http://localhost:8080/mock/1/api/v1/reviews/7
# {"reviewId":1,"content":"sample_content",
#  "author":{"memberId":1,"nickname":"샘플 nickname","email":"sample@timiroom.dev"},
#  "isVerified":true}

# 에러 화면 테스트
curl -H "X-Mock-Error: 503" http://localhost:8080/mock/1/api/v1/reviews

# 로딩 화면 테스트
curl -H "X-Mock-Delay: 3000" http://localhost:8080/mock/1/api/v1/reviews
```
</details>

<details>
<summary>구현 세부 — 응답 생성 방식</summary>

명세의 값은 `"integer // 사용자 ID"` 처럼 타입과 설명이 섞여 있어 타입만 추출해 사용합니다.

타입에 맞는 값을 넣되, 문자열은 필드명까지 보고 그럴듯한 값을 고릅니다.

| 필드명 패턴 | 생성 값 |
|---|---|
| `email` | `sample@timiroom.dev` |
| `password` | `********` |
| `phone`, `tel` | `010-1234-5678` |
| `url`, `image` | `https://cdn.timiroom.dev/sample.png` |
| `date`, `~at` | `2026-01-01T00:00:00` |
| `~id` (integer) | `1` |

프론트가 화면을 붙일 때 의미 없는 더미보다 실제에 가까운 값이 유용하다고 판단했습니다.
</details>

<details>
<summary>패키지 구조</summary>

`#36` DDD 리팩터링 컨벤션에 맞춰 레이어별로 구성했습니다.

```
domain/mock/
├── controller/MockController.java
├── entity/MockApiLog.java
├── repository/MockApiLogRepository.java
└── service/MockService.java
```
</details>

## 관련

- 프론트엔드 연동: timiroom/timiroom-frontend#27
- 이 PR이 먼저 머지돼야 프론트의 Mock 서버 버튼·curl 탭이 실제 응답을 받습니다
