### PR TITLE
fix: 운영 GitHub OAuth 콜백 URI 명시

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,7 @@ spring:
           github:
             client-id: ${GITHUB_CLIENT_ID:dummy}
             client-secret: ${GITHUB_CLIENT_SECRET:dummy}
+            redirect-uri: "${OAUTH2_REDIRECT_BASE_URL:http://localhost:8080}/login/oauth2/code/github"
             scope:
               - user:email
               - read:user


### PR DESCRIPTION
## 변경 사항
- GitHub OAuth redirect URI를 OAUTH2_REDIRECT_BASE_URL 기준으로 명시
- Google과 동일한 운영/로컬 전환 방식을 사용

## 원인
운영 배포에서 프록시 추론 또는 로컬 기본값에 의존해 콜백 주소가 잘못 생성될 수 있었습니다.

## 검증
- .\\gradlew.bat test --no-daemon (성공)