### PR TITLE
feat: 기획·API·DB·코드를 잇는 지식 그래프 추가

### DIFF
--- a/src/main/java/com/timiroom/domain/github/GithubPullRequestReviewRecord.java
+++ b/src/main/java/com/timiroom/domain/github/GithubPullRequestReviewRecord.java
@@ -61,6 +61,35 @@ public class GithubPullRequestReviewRecord {
     @Column(name = "evaluator", length = 40)
     private String evaluator;
 
+    /** 지식 그래프에서 PR 노드에 붙일 이름과 링크 — 그래프를 그릴 때마다 GitHub에 다시 묻지 않는다. */
+    @Column(name = "pull_title", length = 400)
+    private String pullTitle;
+
+    @Column(name = "pull_url", length = 500)
+    private String pullUrl;
+
+    /**
+     * open | closed. 닫히거나 머지된 PR은 지식 그래프에서 내린다.
+     *
+     * 그래프의 PR 노드는 "지금 이걸 건드리는 중"이라는 뜻이다. 머지가 끝난 변경은
+     * 이미 명세와 코드 양쪽에 반영된 사실이지 진행 중인 위험이 아니므로, 남겨 두면
+     * 몇 달 전 작업까지 영향 표시가 켜진 채로 쌓여 정작 지금 봐야 할 것을 덮는다.
+     */
+    @Column(name = "pull_state", length = 20)
+    private String pullState;
+
+    /**
+     * 이 PR이 건드린 API 경로와 테이블 이름.
+     *
+     * 변경 파일에서 뽑아낸 결과를 검사 시점에 저장해 둔다. 지식 그래프는 요청마다
+     * 새로 계산되는데, 그때마다 GitHub에서 변경 파일을 다시 받아오면 호출 한도에 걸리고
+     * 화면도 느려진다. 파일을 이미 손에 쥐고 있는 검사 시점이 뽑아 두기 가장 좋은 자리다.
+     *
+     * 형태: {"apis":["/api/v1/reviews"],"tables":["reviews"],"files":["src/.../ReviewController.java"]}
+     */
+    @Column(name = "touched_json", columnDefinition = "TEXT")
+    private String touchedJson;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -79,5 +108,21 @@ public class GithubPullRequestReviewRecord {
         this.score = score;
         this.findingsJson = findingsJson;
         this.evaluator = evaluator;
+    }
+
+    public void updateGraphContext(String pullTitle, String pullUrl, String pullState, String touchedJson) {
+        this.pullTitle = pullTitle;
+        this.pullUrl = pullUrl;
+        this.pullState = pullState;
+        this.touchedJson = touchedJson;
+    }
+
+    public void markClosed() {
+        this.pullState = "closed";
+    }
+
+    /** 그래프에 올릴 대상인지 — 아직 열려 있고 무엇을 건드렸는지 아는 PR만 */
+    public boolean isOpenForGraph() {
+        return !"closed".equalsIgnoreCase(pullState) && touchedJson != null;
     }
 }

--- a/src/main/java/com/timiroom/domain/github/GithubWebhookService.java
+++ b/src/main/java/com/timiroom/domain/github/GithubWebhookService.java
@@ -8,7 +8,10 @@ import org.springframework.stereotype.Service;
 
 import java.util.Set;
 
-/** pull_request opened/synchronize 이벤트에서 연결 프로젝트의 정합성 review를 자동 실행한다. */
+/**
+ * pull_request 이벤트를 받아 연결 프로젝트의 정합성 review를 자동 실행하고,
+ * PR이 닫히면 지식 그래프에서 내린다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -18,13 +21,16 @@ public class GithubWebhookService {
 
     private final GithubRepoRepository githubRepoRepository;
     private final ProjectRepoLinkRepository projectRepoLinkRepository;
+    private final GithubPullRequestReviewRecordRepository reviewRecordRepository;
     private final PullRequestConsistencyService pullRequestConsistencyService;
 
     @Async
     public void handle(String event, JsonNode payload) {
         if (!"pull_request".equals(event)) return;
         String action = payload.path("action").asText();
-        if (!REVIEW_ACTIONS.contains(action)) return;
+        boolean review = REVIEW_ACTIONS.contains(action);
+        boolean closed = "closed".equals(action);
+        if (!review && !closed) return;
 
         long githubRepoId = payload.path("repository").path("id").asLong(-1);
         int pullNumber = payload.path("number").asInt(-1);
@@ -35,17 +41,37 @@ public class GithubWebhookService {
         githubRepoRepository.findByGithubRepoId(githubRepoId).ifPresentOrElse(repo ->
                         projectRepoLinkRepository.findByGithubRepoId(repo.getId()).forEach(link -> {
                             try {
-                                var result = pullRequestConsistencyService.checkAndReviewFromWebhook(
-                                        link.getProjectId(), repo.getId(), pullNumber);
-                                log.info("GitHub PR 정합성 자동 리뷰 — project={}, repo={}, pr={}, posted={}, duplicate={}",
-                                        link.getProjectId(), repo.getFullName(), pullNumber,
-                                        result.reviewPosted(), result.skippedDuplicate());
+                                if (closed) closeOnGraph(link.getProjectId(), repo, pullNumber, payload);
+                                else runReview(link.getProjectId(), repo, pullNumber);
                             } catch (Exception e) {
                                 // GitHub은 2xx 응답을 받아야 재시도 폭주를 피할 수 있으므로 실패는 로그로 남긴다.
-                                log.error("GitHub PR 정합성 자동 리뷰 실패 — project={}, repo={}, pr={}: {}",
-                                        link.getProjectId(), repo.getFullName(), pullNumber, e.getMessage(), e);
+                                log.error("GitHub pull_request webhook 처리 실패 — project={}, repo={}, pr={}, action={}: {}",
+                                        link.getProjectId(), repo.getFullName(), pullNumber, action, e.getMessage(), e);
                             }
                         }),
                 () -> log.debug("연결되지 않은 GitHub repo webhook 무시 — githubRepoId={}", githubRepoId));
+    }
+
+    private void runReview(Long projectId, GithubRepo repo, int pullNumber) {
+        var result = pullRequestConsistencyService.checkAndReviewFromWebhook(projectId, repo.getId(), pullNumber);
+        log.info("GitHub PR 정합성 자동 리뷰 — project={}, repo={}, pr={}, posted={}, duplicate={}",
+                projectId, repo.getFullName(), pullNumber, result.reviewPosted(), result.skippedDuplicate());
+    }
+
+    /**
+     * 머지되거나 그냥 닫힌 PR을 그래프에서 내린다.
+     *
+     * 검사 기록 자체는 지우지 않는다. 명세 패널이 과거 리뷰 결과를 읽고 있고,
+     * 같은 PR이 다시 열리면(reopened) 그때 상태만 되돌리면 되기 때문이다.
+     */
+    private void closeOnGraph(Long projectId, GithubRepo repo, int pullNumber, JsonNode payload) {
+        reviewRecordRepository.findByProjectIdAndGithubRepoIdAndPullNumber(projectId, repo.getId(), pullNumber)
+                .ifPresent(record -> {
+                    record.markClosed();
+                    reviewRecordRepository.save(record);
+                    log.info("PR 종료로 지식 그래프에서 제외 — project={}, repo={}, pr={}, merged={}",
+                            projectId, repo.getFullName(), pullNumber,
+                            payload.path("pull_request").path("merged").asBoolean(false));
+                });
     }
 }

--- a/src/main/java/com/timiroom/domain/github/PullRequestConsistencyService.java
+++ b/src/main/java/com/timiroom/domain/github/PullRequestConsistencyService.java
@@ -7,6 +7,7 @@ import com.timiroom.domain.github.dto.EvidenceReference;
 import com.timiroom.domain.github.dto.ProjectConsistencySummary;
 import com.timiroom.domain.github.dto.ProjectPullRequestResponse;
 import com.timiroom.domain.github.dto.PullRequestConsistencyResult;
+import com.timiroom.domain.github.dto.PullRequestTouchPoints;
 import com.timiroom.domain.github.dto.RelatedPullRequestResponse;
 import com.timiroom.domain.notification.enums.NotificationReferenceType;
 import com.timiroom.domain.notification.service.NotificationService;
@@ -140,6 +141,10 @@ public class PullRequestConsistencyService {
         int score = inconclusiveCount > 0 ? 0 : Math.max(0, 100 - (int) warningCount * 25);
         String findingsJson = writeFindings(findings);
 
+        // 파일을 손에 쥐고 있는 지금 뽑아 둔다 — 지식 그래프는 요청마다 새로 계산되므로
+        // 그때 GitHub에 다시 물으면 호출 한도에 걸린다.
+        String touchedJson = writeTouchPoints(extractTouchPoints(files));
+
         String reviewBody = reviewMarkdown(score, findings, analysis.evaluator(), analysis.summary(), pullRequest);
         GithubCheckRunInfo checkRun = githubClient.createCompletedConsistencyCheckRun(repo.getFullName(),
                 repo.getInstallationId(), pullRequest.headSha(), score, inconclusiveCount > 0, reviewBody);
@@ -149,10 +154,15 @@ public class PullRequestConsistencyService {
             reviewRecordRepository.save(GithubPullRequestReviewRecord.builder()
                     .projectId(projectId).githubRepoId(repo.getId()).pullNumber(pullNumber)
                     .headSha(pullRequest.headSha()).reviewUrl(review.htmlUrl()).checkRunUrl(checkRun.htmlUrl())
-                    .score(score).findingsJson(findingsJson).evaluator(analysis.evaluator()).build());
+                    .score(score).findingsJson(findingsJson).evaluator(analysis.evaluator())
+                    .pullTitle(pullRequest.title()).pullUrl(pullRequest.htmlUrl())
+                    .pullState(pullRequest.state()).touchedJson(touchedJson)
+                    .build());
         } else {
             existing.updateReview(pullRequest.headSha(), review.htmlUrl(), checkRun.htmlUrl());
             existing.updateResult(score, findingsJson, analysis.evaluator());
+            existing.updateGraphContext(pullRequest.title(), pullRequest.htmlUrl(),
+                    pullRequest.state(), touchedJson);
         }
         if (attentionCount > 0) notifyProjectMembers(projectId, repo, pullNumber, warningCount, inconclusiveCount);
         return new PullRequestConsistencyResult(repo.getId(), pullNumber, pullRequest.headSha(), score,
@@ -397,6 +407,39 @@ public class PullRequestConsistencyService {
         String text = (file.filename() + "\n" + file.patch()).toLowerCase();
         return text.contains("migration") || text.contains("@entity") || text.contains("@table")
                 || text.contains("create table") || text.contains("alter table") || text.contains("@column");
+    }
+
+    /**
+     * 이 PR이 어느 API·테이블을 건드렸는지 뽑는다.
+     *
+     * 규칙 엔진이 명세 대조에 쓰는 것과 같은 정규식을 그대로 쓴다. 지식 그래프에서
+     * 코드와 명세를 잇는 근거가 리뷰에서 쓴 근거와 달라지면, 리뷰는 통과인데 그래프에는
+     * 선이 없는(혹은 그 반대인) 어긋남이 생긴다. 판단 기준은 한 곳이어야 한다.
+     *
+     * diff(patch)만 본다. 파일 전체를 훑으면 이번에 손대지 않은 엔드포인트까지 딸려 와서
+     * "이 PR이 건드린 것"이라는 뜻이 흐려진다.
+     */
+    private PullRequestTouchPoints extractTouchPoints(List<GithubPullRequestFileInfo> files) {
+        Set<String> apis = new java.util.LinkedHashSet<>();
+        Set<String> tables = new java.util.LinkedHashSet<>();
+        List<String> changedFiles = new ArrayList<>();
+
+        for (GithubPullRequestFileInfo file : files) {
+            apis.addAll(extract(API_PATH, file.patch()));
+            tables.addAll(extract(TABLE_ANNOTATION, file.patch()));
+            tables.addAll(extract(TABLE_SQL, file.patch()));
+            changedFiles.add(file.filename());
+        }
+        return new PullRequestTouchPoints(List.copyOf(apis), List.copyOf(tables), List.copyOf(changedFiles));
+    }
+
+    private String writeTouchPoints(PullRequestTouchPoints touchPoints) {
+        try {
+            return objectMapper.writeValueAsString(touchPoints);
+        } catch (Exception e) {
+            log.warn("PR 접점 직렬화 실패: {}", e.getMessage());
+            return null;
+        }
     }
 
     private Set<String> extract(Pattern pattern, String text) {

--- a/src/main/java/com/timiroom/domain/github/dto/PullRequestTouchPoints.java
+++ b/src/main/java/com/timiroom/domain/github/dto/PullRequestTouchPoints.java
@@ -1,0 +1,26 @@
+package com.timiroom.domain.github.dto;
+
+import java.util.List;
+
+/**
+ * 한 PR이 건드린 접점.
+ *
+ * 지식 그래프에서 코드(PR)를 API·테이블에 잇는 근거가 된다.
+ * 정합성 검사 시점에 변경 파일에서 뽑아 review record에 JSON으로 저장해 두고,
+ * 그래프를 그릴 때는 이것만 읽는다.
+ */
+public record PullRequestTouchPoints(
+        List<String> apis,
+        List<String> tables,
+        List<String> files
+) {
+    public PullRequestTouchPoints {
+        apis = apis == null ? List.of() : List.copyOf(apis);
+        tables = tables == null ? List.of() : List.copyOf(tables);
+        files = files == null ? List.of() : List.copyOf(files);
+    }
+
+    public static PullRequestTouchPoints empty() {
+        return new PullRequestTouchPoints(List.of(), List.of(), List.of());
+    }
+}

--- a/src/main/java/com/timiroom/domain/graph/controller/KnowledgeGraphController.java
+++ b/src/main/java/com/timiroom/domain/graph/controller/KnowledgeGraphController.java
@@ -1,13 +1,15 @@
 package com.timiroom.domain.graph.controller;
 
-import com.timiroom.domain.graph.dto.GraphResponse;
 import com.timiroom.domain.graph.service.KnowledgeGraphService;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 /**
  * 지식 그래프 조회
@@ -16,6 +18,10 @@ import org.springframework.web.bind.annotation.RestController;
  *   기능 · API · DB 테이블의 연결 관계를 계산해 반환한다.
  *   저장된 그래프를 읽는 것이 아니라 최신 명세에서 매번 계산하므로
  *   문서를 고치면 그래프도 바로 따라온다.
+ *
+ * 응답에는 기능 목록·API 경로와 설명·테이블 컬럼·PR 제목이 모두 담긴다.
+ * 프로젝트 명세를 통째로 내려주는 것과 같으므로, 소속을 확인하지 않으면
+ * 로그인한 누구나 projectId만 바꿔 남의 프로젝트를 읽을 수 있다.
  */
 @RestController
 @RequestMapping("/api/v1/projects")
@@ -25,7 +31,17 @@ public class KnowledgeGraphController {
     private final KnowledgeGraphService knowledgeGraphService;
 
     @GetMapping("/{projectId}/graph")
-    public ResponseEntity<GraphResponse> graph(@PathVariable Long projectId) {
-        return ResponseEntity.ok(knowledgeGraphService.build(projectId));
+    public ResponseEntity<?> graph(HttpSession session, @PathVariable Long projectId) {
+        Long memberId = (Long) session.getAttribute("memberId");
+        if (memberId == null) {
+            return ResponseEntity.status(401).body(Map.of("error", "Not logged in"));
+        }
+        try {
+            return ResponseEntity.ok(knowledgeGraphService.build(projectId, memberId));
+        } catch (SecurityException e) {
+            return ResponseEntity.status(403).body(Map.of("error", e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(400).body(Map.of("error", e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/timiroom/domain/graph/controller/KnowledgeGraphController.java
+++ b/src/main/java/com/timiroom/domain/graph/controller/KnowledgeGraphController.java
@@ -1,0 +1,31 @@
+package com.timiroom.domain.graph.controller;
+
+import com.timiroom.domain.graph.dto.GraphResponse;
+import com.timiroom.domain.graph.service.KnowledgeGraphService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 지식 그래프 조회
+ *
+ * GET /api/v1/projects/{projectId}/graph
+ *   기능 · API · DB 테이블의 연결 관계를 계산해 반환한다.
+ *   저장된 그래프를 읽는 것이 아니라 최신 명세에서 매번 계산하므로
+ *   문서를 고치면 그래프도 바로 따라온다.
+ */
+@RestController
+@RequestMapping("/api/v1/projects")
+@RequiredArgsConstructor
+public class KnowledgeGraphController {
+
+    private final KnowledgeGraphService knowledgeGraphService;
+
+    @GetMapping("/{projectId}/graph")
+    public ResponseEntity<GraphResponse> graph(@PathVariable Long projectId) {
+        return ResponseEntity.ok(knowledgeGraphService.build(projectId));
+    }
+}

--- a/src/main/java/com/timiroom/domain/graph/dto/GraphResponse.java
+++ b/src/main/java/com/timiroom/domain/graph/dto/GraphResponse.java
@@ -1,0 +1,75 @@
+package com.timiroom.domain.graph.dto;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 지식 그래프 응답
+ *
+ * Cytoscape가 그대로 먹을 수 있는 모양으로 내려준다.
+ * 노드는 도메인(회원·리뷰 등)으로 묶여 있고, parent가 그룹 노드를 가리킨다.
+ */
+public record GraphResponse(
+        List<Node> nodes,
+        List<Edge> edges,
+        Summary summary
+) {
+
+    /**
+     * @param id     고유 식별자 (예: "api:GET:/api/v1/reviews")
+     * @param label  화면에 표시할 이름
+     * @param type   feature | api | table | pr | group
+     * @param parent 소속 그룹 노드 id (그룹 자신은 null)
+     * @param orphan 다른 계층과 연결이 없는 노드 — 설계 불일치 신호
+     * @param change 직전 버전 대비 변화. null이면 그대로 (ADDED | MODIFIED | REMOVED)
+     * @param impacted 스스로 바뀐 건 아니지만 바뀐 것과 이어져 확인이 필요한 노드
+     * @param meta   상세 패널에 쓸 부가 정보
+     */
+    public record Node(
+            String id,
+            String label,
+            String type,
+            String parent,
+            boolean orphan,
+            String change,
+            boolean impacted,
+            Map<String, Object> meta
+    ) {}
+
+    /**
+     * @param source 출발 노드 id
+     * @param target 도착 노드 id
+     * @param type   IMPLEMENTS(기능→API) | STORES(API→테이블) | REFERENCES(테이블→테이블)
+     *               | CHANGES(PR→API·테이블)
+     */
+    public record Edge(
+            String id,
+            String source,
+            String target,
+            String type
+    ) {}
+
+    /**
+     * 그래프 요약 — 화면 상단에 바로 띄울 수 있는 수치
+     *
+     * @param orphanFeatures API가 하나도 연결되지 않은 기능 수
+     * @param orphanApis     기능 목록에 근거가 없는 API 수
+     * @param orphanTables   어떤 API도 쓰지 않는 테이블 수
+     */
+    /**
+     * @param changedCount  직전 버전 대비 실제로 바뀐 노드 수
+     * @param impactedCount 문서 변경과 코드 변경 때문에 확인이 필요해진 노드 수
+     * @param prCount       그래프에 올라온, 정합성 검사를 마친 PR 수
+     */
+    public record Summary(
+            int featureCount,
+            int apiCount,
+            int tableCount,
+            int orphanFeatures,
+            int orphanApis,
+            int orphanTables,
+            int changedCount,
+            int impactedCount,
+            int prCount
+    ) {}
+}

--- a/src/main/java/com/timiroom/domain/graph/service/KnowledgeGraphService.java
+++ b/src/main/java/com/timiroom/domain/graph/service/KnowledgeGraphService.java
@@ -1,0 +1,851 @@
+package com.timiroom.domain.graph.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.timiroom.domain.github.GithubPullRequestReviewRecord;
+import com.timiroom.domain.github.GithubPullRequestReviewRecordRepository;
+import com.timiroom.domain.github.ProjectRepoLink;
+import com.timiroom.domain.github.ProjectRepoLinkRepository;
+import com.timiroom.domain.github.dto.PullRequestTouchPoints;
+import com.timiroom.domain.graph.dto.GraphResponse;
+import com.timiroom.domain.pipeline.entity.PipelineArtifact;
+import com.timiroom.domain.pipeline.repository.ArtifactRevisionRepository;
+import com.timiroom.domain.pipeline.service.PipelineService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * 지식 그래프 — 기능 · API · DB 테이블의 연결 관계를 계산한다.
+ *
+ * 그래프 전용 저장소를 두지 않고 요청 시점에 아티팩트에서 계산한다.
+ * 명세가 수정되면 그래프도 즉시 따라오므로 둘 사이가 어긋날 여지가 없다.
+ *
+ * 연결 규칙:
+ *   기능 → API    설명·경로에 기능의 핵심 단어가 얼마나 등장하는지로 판단
+ *   API  → 테이블  경로의 리소스명과 테이블명을 대조
+ *   테이블 → 테이블 relationships 문자열과 외래키 컬럼에서 추출
+ *   PR   → API·테이블  정합성 검사 때 변경 diff에서 뽑아 둔 접점
+ *
+ * 마지막 규칙이 코드와 기획을 잇는다. PR을 고르면 그 코드가 닿는 API가 나오고,
+ * 그 API를 구현하는 기능(요구사항)까지 선이 이어져 "이 변경이 무엇을 건드리는지"가 드러난다.
+ *
+ * 어느 쪽과도 연결되지 않은 노드는 orphan으로 표시한다.
+ * "명세에는 있는데 기능 목록에 근거가 없는 API" 같은 설계 구멍이 여기서 드러난다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KnowledgeGraphService {
+
+    private final PipelineService pipelineService;
+    private final ArtifactRevisionRepository revisionRepository;
+    private final GithubPullRequestReviewRecordRepository reviewRecordRepository;
+    private final ProjectRepoLinkRepository projectRepoLinkRepository;
+    private final ObjectMapper objectMapper;
+
+    /** 기능의 핵심 단어 중 이 비율 이상이 API 쪽에 등장하면 연결로 본다 */
+    private static final double FEATURE_MATCH_RATIO = 0.5;
+
+    /** 이 이하로 짧은 기능명은 비율 대신 전부 일치를 요구한다 */
+    private static final int SHORT_FEATURE_TOKENS = 2;
+
+    /** 이보다 적게 모이면 묶지 않는다 — 혼자인 묶음은 묶음이 아니다 */
+    private static final int MIN_GROUP_MEMBERS = 2;
+
+    /** 이 비율을 넘는 API 설명에 등장하는 낱말은 변별력이 없다고 본다 */
+    private static final double GENERIC_TOKEN_RATIO = 0.4;
+
+    /** 엔드포인트가 이보다 적으면 낱말 빈도가 우연이라 흔함을 따지지 않는다 */
+    private static final int MIN_CORPUS_FOR_TOKEN_FREQUENCY = 8;
+
+    /** 조사·접미사가 붙어도 걸리도록 부분 일치를 쓰므로, 너무 짧은 단어는 오검출을 만든다 */
+    private static final int MIN_TOKEN_LENGTH = 2;
+
+    /** 경로에서 리소스가 아닌 세그먼트 */
+    private static final Set<String> PATH_NOISE = Set.of("api", "v1", "v2", "v3");
+
+    /**
+     * 영향이 번져 나가는 최대 거리.
+     *
+     * 2로 잡은 건 기획 → API → 테이블이 세 계층이기 때문이다. 어느 계층에서 시작하든
+     * 두 걸음이면 위아래 끝에 닿으므로, 한 변경이 실제로 걸리는 범위는 전부 덮인다.
+     * 세 걸음부터는 외래키를 타고 옆 도메인으로 새기 시작해 신호가 소음이 된다.
+     */
+    private static final int MAX_IMPACT_DEPTH = 2;
+
+    /** "테이블A (1:N) 테이블B" 형태의 관계 서술 */
+    private static final Pattern RELATION = Pattern.compile(
+            "([A-Za-z_][A-Za-z0-9_]*)\\s*\\(\\s*([0-9NM]+\\s*:\\s*[0-9NM]+)\\s*\\)\\s*([A-Za-z_][A-Za-z0-9_]*)");
+
+    @Transactional(readOnly = true)
+    public GraphResponse build(Long projectId) {
+        Map<PipelineArtifact.ArtifactType, JsonNode> artifacts = loadArtifacts(projectId);
+        Map<PipelineArtifact.ArtifactType, JsonNode> previous = loadPreviousArtifacts(projectId);
+
+        List<String> features = readFeatures(artifacts.get(PipelineArtifact.ArtifactType.FEATURE_LIST));
+        List<ApiNode> apis = readApis(artifacts.get(PipelineArtifact.ArtifactType.API_SPEC));
+        List<TableNode> tables = readTables(artifacts.get(PipelineArtifact.ArtifactType.DB_SCHEMA));
+
+        List<GraphResponse.Node> nodes = new ArrayList<>();
+        List<GraphResponse.Edge> edges = new ArrayList<>();
+
+        // 연결된 노드를 기록해 두고, 끝까지 남은 것을 orphan으로 처리한다
+        Set<String> connected = new LinkedHashSet<>();
+
+        // ── 기능 → API ──────────────────────────────────────────────
+        // 이 명세 안에서 흔해빠진 낱말을 먼저 가려낸다. 어느 설명에나 나오는 말은
+        // 무엇을 가리키는지 좁혀 주지 못하므로 연결의 근거로 쓰면 안 된다.
+        Set<String> genericTokens = findGenericTokens(features, apis);
+
+        for (String feature : features) {
+            String featureId = "feature:" + feature;
+            for (ApiNode api : apis) {
+                if (matchesFeature(feature, api, genericTokens)) {
+                    edges.add(new GraphResponse.Edge(
+                            "e:" + featureId + "->" + api.id, featureId, api.id, "IMPLEMENTS"));
+                    connected.add(featureId);
+                    connected.add(api.id);
+                }
+            }
+        }
+
+        // ── API → 테이블 ────────────────────────────────────────────
+        for (ApiNode api : apis) {
+            for (TableNode table : tables) {
+                if (touchesTable(api, table)) {
+                    edges.add(new GraphResponse.Edge(
+                            "e:" + api.id + "->" + table.id, api.id, table.id, "STORES"));
+                    connected.add(api.id);
+                    connected.add(table.id);
+                }
+            }
+        }
+
+        // ── 테이블 → 테이블 ─────────────────────────────────────────
+        Map<String, TableNode> tableByName = new LinkedHashMap<>();
+        tables.forEach(t -> tableByName.put(t.name, t));
+
+        for (Edge relation : readRelations(artifacts.get(PipelineArtifact.ArtifactType.DB_SCHEMA), tableByName)) {
+            edges.add(new GraphResponse.Edge(
+                    "e:" + relation.from + "->" + relation.to, relation.from, relation.to, "REFERENCES"));
+        }
+
+        // ── PR(코드) → API·테이블 ───────────────────────────────────
+        // 여기서 코드가 기획에 붙는다. PR이 닿은 API를 거쳐 그 API를 구현하는
+        // 기능까지 선이 이어지므로, PR 하나를 고르면 그 변경이 어떤 요구사항에
+        // 걸리는지가 그림에서 그대로 따라온다.
+        List<PullRequestNode> pullRequests = readPullRequests(projectId);
+        Set<String> codeTouched = new LinkedHashSet<>();
+
+        for (PullRequestNode pr : pullRequests) {
+            for (ApiNode api : apis) {
+                if (pr.touchesApi(api.path)) {
+                    edges.add(new GraphResponse.Edge(
+                            "e:" + pr.id + "->" + api.id, pr.id, api.id, "CHANGES"));
+                    connected.add(api.id);
+                    codeTouched.add(api.id);
+                }
+            }
+            for (TableNode table : tables) {
+                if (pr.touchesTable(table.name)) {
+                    edges.add(new GraphResponse.Edge(
+                            "e:" + pr.id + "->" + table.id, pr.id, table.id, "CHANGES"));
+                    connected.add(table.id);
+                    codeTouched.add(table.id);
+                }
+            }
+        }
+
+        // ── 그룹(도메인) 노드 ───────────────────────────────────────
+        // 리소스명을 기준으로 묶는다. reviews · review_scores → review 그룹
+        Map<String, String> groupLabels = new LinkedHashMap<>();
+        Map<String, String> parentOf = new LinkedHashMap<>();
+
+        for (ApiNode api : apis) {
+            String key = api.group;
+            groupLabels.putIfAbsent(key, key);
+            parentOf.put(api.id, "group:" + key);
+        }
+        for (TableNode table : tables) {
+            String key = table.group;
+            groupLabels.putIfAbsent(key, key);
+            parentOf.put(table.id, "group:" + key);
+        }
+        // 기능은 연결된 API의 그룹을 따라간다. 연결이 없으면 묶지 않는다.
+        for (String feature : features) {
+            String featureId = "feature:" + feature;
+            edges.stream()
+                    .filter(e -> e.source().equals(featureId))
+                    .findFirst()
+                    .map(e -> parentOf.get(e.target()))
+                    .ifPresent(group -> parentOf.put(featureId, group));
+        }
+
+        // 혼자 남는 묶음은 만들지 않는다.
+        //
+        // 첫 낱말로 묶다 보면 refresh_tokens 하나뿐인 `refresh` 같은 묶음이 생긴다.
+        // 구성원이 하나면 그건 묶음이 아니라 노드 옆에 붙은 라벨일 뿐이라, 화면에는
+        // 아무것도 알려주지 않으면서 자리만 차지하고 배치까지 끌어당긴다.
+        Map<String, Long> memberCount = parentOf.values().stream()
+                .collect(Collectors.groupingBy(g -> g, Collectors.counting()));
+        parentOf.values().removeIf(group -> memberCount.getOrDefault(group, 0L) < MIN_GROUP_MEMBERS);
+
+        groupLabels.forEach((key, label) -> {
+            if (memberCount.getOrDefault("group:" + key, 0L) >= MIN_GROUP_MEMBERS) {
+                nodes.add(new GraphResponse.Node(
+                        "group:" + key, label, "group", null, false, null, false, Map.of()));
+            }
+        });
+
+        // ── 변경 판정 ───────────────────────────────────────────────
+        // 직전 버전에서 같은 규칙으로 노드를 뽑아 지금과 견준다.
+        Changes changes = detectChanges(previous, features, apis, tables);
+
+        // 영향의 출발점은 두 갈래다. 문서를 고쳐서 생긴 변경과, 코드를 고쳐서 생긴 변경.
+        // PR이 건드린 API·테이블도 출발점에 넣어야 "이 PR을 머지하면 어디가 흔들리는지"가
+        // 문서 변경과 같은 방식으로 그림에 나타난다.
+        Set<String> impactSeeds = new LinkedHashSet<>(changes.changedIds());
+        impactSeeds.addAll(codeTouched);
+        Set<String> impacted = spreadImpact(impactSeeds, edges);
+
+        // ── 노드 생성 ───────────────────────────────────────────────
+        int orphanFeatures = 0, orphanApis = 0, orphanTables = 0;
+
+        for (String feature : features) {
+            String id = "feature:" + feature;
+            boolean orphan = !connected.contains(id);
+            if (orphan) orphanFeatures++;
+            nodes.add(node(id, feature, "feature", parentOf.get(id), orphan, changes, impacted,
+                    Map.of("hint", orphan ? "이 기능을 구현하는 API를 찾지 못했습니다" : "")));
+        }
+
+        for (ApiNode api : apis) {
+            boolean orphan = !connected.contains(api.id);
+            if (orphan) orphanApis++;
+            nodes.add(node(api.id, api.method + " " + api.path, "api",
+                    parentOf.get(api.id), orphan, changes, impacted,
+                    Map.of(
+                            "method", api.method,
+                            "path", api.path,
+                            "description", api.description,
+                            "authRequired", api.authRequired,
+                            "hint", orphan ? "기능 목록에서 이 API의 근거를 찾지 못했습니다" : "",
+                            // 중복은 고아와 달리 연결이 멀쩡해 클릭할 일이 없다.
+                            // 그래도 남겨 두어야 명세를 손볼 때 근거가 된다.
+                            "notice", api.duplicates > 1
+                                    ? "이 엔드포인트가 명세에 " + api.duplicates + "번 적혀 있습니다"
+                                    : ""
+                    )));
+        }
+
+        for (TableNode table : tables) {
+            boolean orphan = !connected.contains(table.id);
+            if (orphan) orphanTables++;
+            nodes.add(node(table.id, table.name, "table",
+                    parentOf.get(table.id), orphan, changes, impacted,
+                    Map.of(
+                            "columns", table.columns,
+                            "hint", orphan ? "이 테이블을 사용하는 API를 찾지 못했습니다" : ""
+                    )));
+        }
+
+        for (PullRequestNode pr : pullRequests) {
+            // PR은 orphan으로 세지 않는다. 명세에 걸리는 게 없는 PR은 설계 구멍이 아니라
+            // 그냥 리팩터링·설정 변경일 수 있고, 그걸 빨간 신호로 만들면 오히려 신뢰를 잃는다.
+            nodes.add(new GraphResponse.Node(pr.id, pr.label, "pr", null, false, null, false,
+                    Map.of(
+                            "repository", pr.repository,
+                            "pullNumber", pr.pullNumber,
+                            "url", pr.url,
+                            "score", pr.score,
+                            "evaluator", pr.evaluator,
+                            "warnings", pr.warnings,
+                            "files", pr.touched.files(),
+                            "reviewUrl", pr.reviewUrl
+                    )));
+        }
+
+        // 사라진 항목은 지금 목록에 없으므로 따로 노드를 만들어 둔다.
+        // "무엇이 없어졌는지"가 영향 확인에서 가장 중요한 정보다.
+        for (Map.Entry<String, RemovedNode> removed : changes.removed().entrySet()) {
+            RemovedNode r = removed.getValue();
+            nodes.add(new GraphResponse.Node(removed.getKey(), r.label(), r.type(), null, false,
+                    "REMOVED", false,
+                    Map.of("hint", "직전 버전에 있었지만 지금은 없습니다")));
+        }
+
+        long changedCount = changes.changedIds().size() + changes.removed().size();
+        long impactedCount = impacted.stream().filter(id -> !impactSeeds.contains(id)).count();
+
+        log.info("지식 그래프 생성 | projectId: {}, 노드 {}, 엣지 {} (고아 {}/{}/{}, PR {}, 변경 {}, 영향 {})",
+                projectId, nodes.size(), edges.size(),
+                orphanFeatures, orphanApis, orphanTables, pullRequests.size(), changedCount, impactedCount);
+
+        return new GraphResponse(nodes, edges, new GraphResponse.Summary(
+                features.size(), apis.size(), tables.size(),
+                orphanFeatures, orphanApis, orphanTables,
+                (int) changedCount, (int) impactedCount, pullRequests.size()));
+    }
+
+    /** 변경·영향 표시를 붙여 노드를 만든다 */
+    private GraphResponse.Node node(String id, String label, String type, String parent,
+                                    boolean orphan, Changes changes, Set<String> impacted,
+                                    Map<String, Object> meta) {
+        String change = changes.changeOf(id);
+        boolean isImpacted = change == null && impacted.contains(id);
+        return new GraphResponse.Node(id, label, type, parent, orphan, change, isImpacted, meta);
+    }
+
+    /* ══════════════════════════════════════
+       변경 감지와 영향 전파
+    ══════════════════════════════════════ */
+
+    /**
+     * @param added    새로 생긴 노드 id
+     * @param modified 내용이 달라진 노드 id
+     * @param removed  없어진 노드 — 지금 목록에 없으므로 표시용 정보를 함께 들고 있는다
+     */
+    private record Changes(Set<String> added, Set<String> modified, Map<String, RemovedNode> removed) {
+
+        Set<String> changedIds() {
+            Set<String> all = new LinkedHashSet<>(added);
+            all.addAll(modified);
+            return all;
+        }
+
+        String changeOf(String id) {
+            if (added.contains(id)) return "ADDED";
+            if (modified.contains(id)) return "MODIFIED";
+            return null;
+        }
+    }
+
+    private record RemovedNode(String label, String type) {}
+
+    /**
+     * 직전 버전과 견주어 무엇이 바뀌었는지 가려낸다.
+     *
+     * 같은 노드인지는 id로 판단하고, 남아 있는 노드는 내용까지 비교한다.
+     * API는 설명·인증 여부가, 테이블은 컬럼 구성이 바뀌면 손댄 것으로 본다 —
+     * 컬럼이 하나 사라지는 것만으로도 그 테이블을 쓰는 API가 깨질 수 있기 때문이다.
+     */
+    private Changes detectChanges(Map<PipelineArtifact.ArtifactType, JsonNode> previous,
+                                  List<String> features, List<ApiNode> apis, List<TableNode> tables) {
+
+        // 이력이 없으면 비교 대상이 없다 — 전부 "그대로"로 둔다
+        if (previous.isEmpty()) {
+            return new Changes(Set.of(), Set.of(), Map.of());
+        }
+
+        Set<String> added = new LinkedHashSet<>();
+        Set<String> modified = new LinkedHashSet<>();
+        Map<String, RemovedNode> removed = new LinkedHashMap<>();
+
+        // 문서 종류마다 따로 판단한다.
+        // 이력이 없는 문서는 비교 대상이 없으므로 손대지 않는다 —
+        // 여기서 통째로 비교하면 한 번도 수정되지 않은 문서의 항목이
+        // 전부 "새로 추가됨"으로 잘못 표시된다.
+
+        JsonNode previousFeatures = previous.get(PipelineArtifact.ArtifactType.FEATURE_LIST);
+        if (previousFeatures != null) {
+            List<String> oldFeatures = readFeatures(previousFeatures);
+            Set<String> oldIds = oldFeatures.stream().map(f -> "feature:" + f).collect(Collectors.toSet());
+            Set<String> newIds = features.stream().map(f -> "feature:" + f).collect(Collectors.toSet());
+
+            newIds.stream().filter(id -> !oldIds.contains(id)).forEach(added::add);
+            for (String feature : oldFeatures) {
+                String id = "feature:" + feature;
+                if (!newIds.contains(id)) removed.put(id, new RemovedNode(feature, "feature"));
+            }
+        }
+
+        JsonNode previousApis = previous.get(PipelineArtifact.ArtifactType.API_SPEC);
+        if (previousApis != null) {
+            Map<String, ApiNode> oldById = readApis(previousApis).stream()
+                    .collect(Collectors.toMap(a -> a.id, a -> a, (a, b) -> a, LinkedHashMap::new));
+
+            for (ApiNode api : apis) {
+                ApiNode before = oldById.get(api.id);
+                if (before == null) {
+                    added.add(api.id);
+                } else if (!before.description.equals(api.description)
+                        || before.authRequired != api.authRequired) {
+                    modified.add(api.id);
+                }
+            }
+            Set<String> newIds = apis.stream().map(a -> a.id).collect(Collectors.toSet());
+            oldById.forEach((id, a) -> {
+                if (!newIds.contains(id)) removed.put(id, new RemovedNode(a.method + " " + a.path, "api"));
+            });
+        }
+
+        JsonNode previousTables = previous.get(PipelineArtifact.ArtifactType.DB_SCHEMA);
+        if (previousTables != null) {
+            Map<String, TableNode> oldById = readTables(previousTables).stream()
+                    .collect(Collectors.toMap(t -> t.id, t -> t, (a, b) -> a, LinkedHashMap::new));
+
+            for (TableNode table : tables) {
+                TableNode before = oldById.get(table.id);
+                if (before == null) {
+                    added.add(table.id);
+                } else if (!before.columns.equals(table.columns)) {
+                    modified.add(table.id);
+                }
+            }
+            Set<String> newIds = tables.stream().map(t -> t.id).collect(Collectors.toSet());
+            oldById.forEach((id, t) -> {
+                if (!newIds.contains(id)) removed.put(id, new RemovedNode(t.name, "table"));
+            });
+        }
+
+        return new Changes(added, modified, removed);
+    }
+
+    /**
+     * 바뀐 노드에서 연결을 따라가며 확인이 필요한 노드를 모은다.
+     *
+     * 방향을 한쪽으로만 보지 않는다. 테이블이 바뀌면 그것을 쓰는 API(들어오는 방향)가
+     * 영향을 받고, 기능이 바뀌면 그것을 구현한 API(나가는 방향)가 영향을 받기 때문이다.
+     * 양방향으로 퍼뜨리되 이미 담은 노드는 다시 타지 않아 순환에도 멈춘다.
+     *
+     * 다만 끝까지 퍼뜨리지는 않는다. 테이블끼리 외래키로 이어진 실제 스키마에서는
+     * users 하나만 건드려도 온 그래프가 한 덩어리로 이어져, 컬럼 하나 늘렸는데
+     * 절반이 "확인 필요"가 된다. 전부 빨간불이면 아무것도 빨간불이 아닌 것과 같다.
+     */
+    private Set<String> spreadImpact(Set<String> changedIds, List<GraphResponse.Edge> edges) {
+        if (changedIds.isEmpty()) return Set.of();
+
+        Map<String, List<String>> neighbours = new LinkedHashMap<>();
+        for (GraphResponse.Edge edge : edges) {
+            neighbours.computeIfAbsent(edge.source(), k -> new ArrayList<>()).add(edge.target());
+            neighbours.computeIfAbsent(edge.target(), k -> new ArrayList<>()).add(edge.source());
+        }
+
+        Set<String> visited = new LinkedHashSet<>(changedIds);
+        Deque<String> queue = new ArrayDeque<>(changedIds);
+        Map<String, Integer> depthOf = new LinkedHashMap<>();
+        changedIds.forEach(id -> depthOf.put(id, 0));
+
+        while (!queue.isEmpty()) {
+            String current = queue.poll();
+            int depth = depthOf.getOrDefault(current, 0);
+            if (depth >= MAX_IMPACT_DEPTH) continue;
+
+            for (String next : neighbours.getOrDefault(current, List.of())) {
+                if (visited.add(next)) {
+                    depthOf.put(next, depth + 1);
+                    queue.add(next);
+                }
+            }
+        }
+        return visited;
+    }
+
+    /* ══════════════════════════════════════
+       연결 판정
+    ══════════════════════════════════════ */
+
+    /**
+     * 기능이 이 API로 구현되는지 판단한다.
+     *
+     * 한국어는 조사가 붙어 형태가 달라지므로("검증" vs "검증된") 정확히 같은 낱말을
+     * 찾지 않고 부분 일치로 센다. 핵심 단어의 절반 이상이 API 설명·경로에 등장하면
+     * 같은 대상을 말하는 것으로 본다.
+     *
+     * 다만 낱말이 적으면 비율만으로는 못 믿는다. 두 낱말짜리 기능은 하나만 겹쳐도
+     * 곧바로 50%가 되기 때문이다. 실제로 "쿠폰 발급"이 "로그인: 사용자 인증 및 JWT 발급"에
+     * `발급` 하나로 걸려 엉뚱하게 이어졌다. 여섯 낱말 중 셋이 겹치는 것과 둘 중 하나가
+     * 겹치는 것은 같은 50%라도 증거의 무게가 다르다.
+     * 그래서 짧은 기능명은 낱말이 모두 나와야 같은 대상으로 본다.
+     *
+     * 흔한 낱말은 아예 세지 않는다. `사용자`·`정보` 같은 말은 이 명세의 거의 모든
+     * 설명에 나와서 어느 API를 가리키는지 조금도 좁혀 주지 못한다. 실제로
+     * "사용자 정보 조회"가 "식성 프로필: 등록된 사용자별 선호 음식 정보 …"에
+     * `사용자`·`정보` 둘로 걸려 엉뚱하게 이어졌다.
+     */
+    private boolean matchesFeature(String feature, ApiNode api, Set<String> genericTokens) {
+        List<String> tokens = tokenize(feature);
+        if (tokens.isEmpty()) return false;
+
+        List<String> distinctive = tokens.stream().filter(t -> !genericTokens.contains(t)).toList();
+        // 남는 게 없으면 이 기능은 흔한 말로만 이루어져 있다는 뜻이다.
+        // 그럴 때는 원래 낱말을 그대로 쓰되 전부 나와야 한다고 본다 — 근거가 약할수록 엄하게.
+        List<String> judged = distinctive.isEmpty() ? tokens : distinctive;
+
+        String haystack = (api.description + " " + api.path).toLowerCase();
+        long hit = judged.stream().filter(haystack::contains).count();
+
+        if (judged.size() <= SHORT_FEATURE_TOKENS) return hit == judged.size();
+        return (double) hit / judged.size() >= FEATURE_MATCH_RATIO;
+    }
+
+    /**
+     * 이 명세 안에서 변별력을 잃은 낱말을 고른다.
+     *
+     * 절반 가까운 API 설명에 나오는 말은 "여기 있다"는 사실이 아무것도 알려주지 않는다.
+     * 문서 빈도가 높을수록 정보량이 적다는, 검색에서 오래 쓰인 생각을 그대로 쓴다.
+     *
+     * 엔드포인트가 몇 개뿐이면 빈도 자체가 우연이라 적용하지 않는다.
+     * 두 개짜리 명세에서는 한 번만 나와도 곧바로 50%가 되기 때문이다.
+     */
+    private Set<String> findGenericTokens(List<String> features, List<ApiNode> apis) {
+        if (apis.size() < MIN_CORPUS_FOR_TOKEN_FREQUENCY) return Set.of();
+
+        List<String> haystacks = apis.stream()
+                .map(api -> (api.description + " " + api.path).toLowerCase())
+                .toList();
+
+        Set<String> candidates = features.stream()
+                .flatMap(feature -> tokenize(feature).stream())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        Set<String> generic = new LinkedHashSet<>();
+        for (String token : candidates) {
+            long appearsIn = haystacks.stream().filter(text -> text.contains(token)).count();
+            if ((double) appearsIn / haystacks.size() > GENERIC_TOKEN_RATIO) generic.add(token);
+        }
+        return generic;
+    }
+
+    /** API 경로가 이 테이블을 다루는지 — 경로의 리소스명과 테이블명을 대조한다 */
+    private boolean touchesTable(ApiNode api, TableNode table) {
+        String name = wordSeparated(table.name);
+        for (String rawSegment : resourceSegments(api.path)) {
+            String segment = wordSeparated(rawSegment);
+            if (name.equals(segment)) return true;
+            if (name.equals(singular(segment)) || singular(name).equals(singular(segment))) return true;
+            // reviews 경로가 review_scores 같은 하위 테이블도 포함하도록
+            if (name.startsWith(singular(segment) + "_")) return true;
+        }
+        return false;
+    }
+
+    /**
+     * 낱말 구분자를 밑줄로 통일한다.
+     *
+     * REST 경로는 하이픈(`/food-profiles`)을, DB 테이블은 밑줄(`food_profiles`)을 쓰는 것이
+     * 양쪽의 관례다. 글자만 놓고 비교하면 같은 대상을 가리키는데도 어긋나서, 멀쩡히 이어진
+     * 테이블이 "이 테이블을 쓰는 API가 없다"는 설계 구멍으로 잘못 보고된다.
+     */
+    private String wordSeparated(String word) {
+        return word.toLowerCase().replace('-', '_');
+    }
+
+    /* ══════════════════════════════════════
+       아티팩트 읽기
+    ══════════════════════════════════════ */
+
+    /**
+     * 각 아티팩트의 직전 버전을 읽는다. 이력이 없는 문서는 결과에 담기지 않는다.
+     * 한 번도 수정된 적 없는 프로젝트라면 비어 있어 변경 비교를 건너뛴다.
+     */
+    private Map<PipelineArtifact.ArtifactType, JsonNode> loadPreviousArtifacts(Long projectId) {
+        Map<PipelineArtifact.ArtifactType, JsonNode> result = new LinkedHashMap<>();
+        for (PipelineArtifact artifact : pipelineService.getLatestArtifactsByProject(projectId)) {
+            revisionRepository.findFirstByArtifactIdOrderByVersionDesc(artifact.getArtifactId())
+                    .ifPresent(revision -> {
+                        try {
+                            result.putIfAbsent(artifact.getArtifactType(),
+                                    objectMapper.readTree(revision.getContent()));
+                        } catch (Exception e) {
+                            log.warn("이전 버전 파싱 실패 | artifactId: {}", artifact.getArtifactId());
+                        }
+                    });
+        }
+        return result;
+    }
+
+    /**
+     * 이 프로젝트에 연결된 레포에서 정합성 검사를 마친 PR을 읽는다.
+     *
+     * 검사 기록이 없는 PR은 그래프에 올리지 않는다. 접점을 뽑아 둔 시점이 곧 검사 시점이라
+     * 기록이 없으면 무엇을 건드렸는지 알 수 없고, 이름만 띄운 노드는 선이 없어 오히려
+     * "아무 데도 영향이 없다"는 잘못된 인상을 준다.
+     *
+     * 닫히거나 머지된 PR도 내린다 — 여기 있는 PR은 "지금 진행 중"이라는 뜻이어야 한다.
+     */
+    private List<PullRequestNode> readPullRequests(Long projectId) {
+        List<Long> repoIds = projectRepoLinkRepository.findByProjectId(projectId).stream()
+                .map(ProjectRepoLink::getGithubRepoId)
+                .toList();
+        if (repoIds.isEmpty()) return List.of();
+
+        List<PullRequestNode> result = new ArrayList<>();
+        for (GithubPullRequestReviewRecord record : reviewRecordRepository
+                .findByProjectIdAndGithubRepoIdIn(projectId, repoIds)) {
+            if (!record.isOpenForGraph()) continue;
+
+            PullRequestTouchPoints touched;
+            try {
+                touched = objectMapper.readValue(record.getTouchedJson(), PullRequestTouchPoints.class);
+            } catch (Exception e) {
+                log.warn("PR 접점 파싱 실패 | pr: #{}", record.getPullNumber());
+                continue;
+            }
+            if (touched.apis().isEmpty() && touched.tables().isEmpty()) continue;
+
+            String title = record.getPullTitle() == null ? "" : record.getPullTitle();
+            result.add(new PullRequestNode(
+                    "pr:" + record.getGithubRepoId() + ":" + record.getPullNumber(),
+                    "#" + record.getPullNumber() + (title.isBlank() ? "" : " " + title),
+                    record.getPullNumber(),
+                    record.getPullUrl() == null ? "" : record.getPullUrl(),
+                    record.getReviewUrl() == null ? "" : record.getReviewUrl(),
+                    String.valueOf(record.getGithubRepoId()),
+                    record.getScore() == null ? 0 : record.getScore(),
+                    record.getEvaluator() == null ? "" : record.getEvaluator(),
+                    countWarnings(record.getFindingsJson()),
+                    touched));
+        }
+        return result;
+    }
+
+    /** 경고 건수만 센다 — 그래프에는 몇 건인지가 필요하고, 본문은 명세 패널이 이미 보여준다 */
+    private int countWarnings(String findingsJson) {
+        if (findingsJson == null) return 0;
+        try {
+            int warnings = 0;
+            for (JsonNode finding : objectMapper.readTree(findingsJson)) {
+                if ("WARNING".equalsIgnoreCase(finding.path("severity").asText())) warnings++;
+            }
+            return warnings;
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+    private Map<PipelineArtifact.ArtifactType, JsonNode> loadArtifacts(Long projectId) {
+        Map<PipelineArtifact.ArtifactType, JsonNode> result = new LinkedHashMap<>();
+        for (PipelineArtifact artifact : pipelineService.getLatestArtifactsByProject(projectId)) {
+            try {
+                result.putIfAbsent(artifact.getArtifactType(), objectMapper.readTree(artifact.getContent()));
+            } catch (Exception e) {
+                log.warn("아티팩트 파싱 실패 | type: {}, projectId: {}", artifact.getArtifactType(), projectId);
+            }
+        }
+        return result;
+    }
+
+    /** FEATURE_LIST는 배열로 저장되기도 하고 {"featureList": [...]} 로 감싸지기도 한다 */
+    private List<String> readFeatures(JsonNode root) {
+        List<String> features = new ArrayList<>();
+        if (root == null) return features;
+
+        JsonNode array = root.isArray() ? root : root.path("featureList");
+        if (!array.isArray()) return features;
+
+        for (JsonNode item : array) {
+            String value = item.isTextual() ? item.asText() : item.path("featureName").asText("");
+            if (!value.isBlank()) features.add(value.trim());
+        }
+        return features;
+    }
+
+    /**
+     * API 명세에서 엔드포인트를 읽는다.
+     *
+     * 같은 method·path가 두 번 적혀 있는 일이 실제로 있다. 그대로 두면 id가 같은 노드가
+     * 둘 생기고, 화면 라이브러리가 뒤엣것을 말없이 버려 "노드 수는 맞는데 그림에는 하나"인
+     * 상태가 된다. 조용히 사라지는 건 가장 나쁜 실패라, 여기서 합치고 몇 번 적혔는지를
+     * 남겨 명세를 손볼 근거로 쓴다.
+     */
+    private List<ApiNode> readApis(JsonNode root) {
+        Map<String, ApiNode> byId = new LinkedHashMap<>();
+        Map<String, Integer> seen = new LinkedHashMap<>();
+        if (root == null) return List.of();
+
+        JsonNode endpoints = root.isArray() ? root : root.path("endpoints");
+        if (!endpoints.isArray()) return List.of();
+
+        for (JsonNode endpoint : endpoints) {
+            String method = endpoint.path("method").asText("GET").toUpperCase();
+            String path = endpoint.path("path").asText("");
+            if (path.isBlank()) continue;
+
+            String id = "api:" + method + ":" + path;
+            seen.merge(id, 1, Integer::sum);
+
+            // 먼저 적힌 쪽을 남긴다 — 뒤에 붙은 중복은 대개 설명이 짧아진 사본이다
+            byId.putIfAbsent(id, new ApiNode(
+                    id,
+                    method,
+                    path,
+                    endpoint.path("description").asText(""),
+                    endpoint.path("authRequired").asBoolean(false),
+                    groupKeyOfPath(path),
+                    1
+            ));
+        }
+
+        return byId.values().stream()
+                .map(api -> api.withDuplicates(seen.getOrDefault(api.id, 1)))
+                .toList();
+    }
+
+    private List<TableNode> readTables(JsonNode root) {
+        List<TableNode> tables = new ArrayList<>();
+        if (root == null) return tables;
+
+        JsonNode array = root.isArray() ? root : root.path("tables");
+        if (!array.isArray()) return tables;
+
+        for (JsonNode table : array) {
+            String name = table.path("name").asText("");
+            if (name.isBlank()) continue;
+
+            List<String> columns = new ArrayList<>();
+            for (JsonNode column : table.path("columns")) {
+                String columnName = column.isTextual() ? column.asText() : column.path("name").asText("");
+                if (!columnName.isBlank()) columns.add(columnName);
+            }
+            tables.add(new TableNode("table:" + name, name, columns, groupKeyOfName(name)));
+        }
+        return tables;
+    }
+
+    /** relationships 서술과 외래키 컬럼에서 테이블 간 참조를 뽑는다 */
+    private List<Edge> readRelations(JsonNode root, Map<String, TableNode> tableByName) {
+        List<Edge> relations = new ArrayList<>();
+        if (root == null) return relations;
+
+        for (JsonNode item : root.path("relationships")) {
+            Matcher matcher = RELATION.matcher(item.asText(""));
+            while (matcher.find()) {
+                TableNode from = tableByName.get(matcher.group(1));
+                TableNode to = tableByName.get(matcher.group(3));
+                if (from != null && to != null && !from.id.equals(to.id)) {
+                    relations.add(new Edge(from.id, to.id));
+                }
+            }
+        }
+
+        // {테이블}_id 컬럼은 그 테이블을 참조한다고 본다
+        for (TableNode table : tableByName.values()) {
+            for (String column : table.columns) {
+                if (!column.endsWith("_id")) continue;
+                String referenced = column.substring(0, column.length() - 3);
+                tableByName.values().stream()
+                        .filter(t -> !t.id.equals(table.id))
+                        .filter(t -> singular(t.name).equals(singular(referenced)))
+                        .findFirst()
+                        .ifPresent(t -> relations.add(new Edge(table.id, t.id)));
+            }
+        }
+        return relations;
+    }
+
+    /* ══════════════════════════════════════
+       문자열 도우미
+    ══════════════════════════════════════ */
+
+    /** 기능 문구를 비교용 단어로 자른다. 너무 짧은 조각은 오검출을 만들어 버린다 */
+    private List<String> tokenize(String text) {
+        return Arrays.stream(text.toLowerCase().split("[^가-힣a-z0-9]+"))
+                .filter(t -> t.length() >= MIN_TOKEN_LENGTH)
+                .toList();
+    }
+
+    /** 경로에서 버전·변수를 걷어내고 리소스 세그먼트만 남긴다 */
+    private List<String> resourceSegments(String path) {
+        return Arrays.stream(path.toLowerCase().split("/"))
+                .filter(s -> !s.isBlank())
+                .filter(s -> !s.startsWith("{"))
+                .filter(s -> !PATH_NOISE.contains(s))
+                .toList();
+    }
+
+    /**
+     * 도메인 묶음의 열쇠 — 첫 낱말 하나.
+     *
+     * 경로와 테이블 모두 구분자를 통일한 뒤 첫 낱말만 본다.
+     * `/food-profiles`와 `food_menus`가 같은 `food` 묶음으로 들어가야
+     * 화면에서 한 도메인으로 모인다. 통일하지 않으면 같은 도메인이
+     * `food-profile`과 `food`로 갈라져 묶음이 잘게 부서진다.
+     */
+    private String groupKeyOfPath(String path) {
+        List<String> segments = resourceSegments(path);
+        return segments.isEmpty() ? "기타" : groupKeyOfName(segments.get(0));
+    }
+
+    private String groupKeyOfName(String name) {
+        return singular(wordSeparated(name).split("_")[0]);
+    }
+
+    /** 영어 복수형을 대략 단수로 맞춘다. 테이블명과 경로를 비교하려면 이 정도는 필요하다 */
+    private String singular(String word) {
+        if (word.endsWith("ies") && word.length() > 3) return word.substring(0, word.length() - 3) + "y";
+        if (word.endsWith("ses") && word.length() > 3) return word.substring(0, word.length() - 2);
+        if (word.endsWith("s") && !word.endsWith("ss") && word.length() > 1) {
+            return word.substring(0, word.length() - 1);
+        }
+        return word;
+    }
+
+    /* ── 내부 표현 ── */
+
+    /** @param duplicates 명세에 이 엔드포인트가 적힌 횟수. 1이면 정상 */
+    private record ApiNode(String id, String method, String path, String description,
+                           boolean authRequired, String group, int duplicates) {
+
+        ApiNode withDuplicates(int count) {
+            return new ApiNode(id, method, path, description, authRequired, group, count);
+        }
+    }
+
+    private record TableNode(String id, String name, List<String> columns, String group) {}
+
+    private record Edge(String from, String to) {}
+
+    /** 정합성 검사를 마친 PR 하나 — 코드 쪽 노드 */
+    private record PullRequestNode(String id, String label, int pullNumber, String url, String reviewUrl,
+                                   String repository, int score, String evaluator, int warnings,
+                                   PullRequestTouchPoints touched) {
+
+        /**
+         * diff에서 뽑은 경로가 이 엔드포인트를 가리키는지.
+         *
+         * 양쪽을 그대로 견주지 않는다. 코드에는 `/api/v1/reviews/{reviewId}`가 문자열
+         * 상수로 쪼개져 있거나 클래스의 @RequestMapping과 메서드 매핑이 나뉘어 있어,
+         * diff에서 건진 조각이 명세의 전체 경로와 정확히 같은 경우는 드물다.
+         * 한쪽이 다른 쪽을 품고 있으면 같은 엔드포인트를 말하는 것으로 본다.
+         */
+        boolean touchesApi(String specPath) {
+            String spec = normalizePath(specPath);
+            if (spec.isBlank()) return false;
+            for (String candidate : touched.apis()) {
+                String found = normalizePath(candidate);
+                if (found.isBlank()) continue;
+                if (spec.equals(found) || spec.startsWith(found) || found.startsWith(spec)) return true;
+            }
+            return false;
+        }
+
+        boolean touchesTable(String tableName) {
+            return touched.tables().stream().anyMatch(name -> {
+                String bare = name.contains(".") ? name.substring(name.lastIndexOf('.') + 1) : name;
+                return bare.equalsIgnoreCase(tableName);
+            });
+        }
+
+        /** 경로 변수는 이름이 서로 달라도 같은 자리다 — {reviewId}와 {id}를 같게 본다 */
+        private static String normalizePath(String path) {
+            if (path == null) return "";
+            return path.toLowerCase().replaceAll("\\{[^}]*}", "{}").replaceAll("/+$", "").trim();
+        }
+    }
+}

--- a/src/main/java/com/timiroom/domain/graph/service/KnowledgeGraphService.java
+++ b/src/main/java/com/timiroom/domain/graph/service/KnowledgeGraphService.java
@@ -11,6 +11,7 @@ import com.timiroom.domain.graph.dto.GraphResponse;
 import com.timiroom.domain.pipeline.entity.PipelineArtifact;
 import com.timiroom.domain.pipeline.repository.ArtifactRevisionRepository;
 import com.timiroom.domain.pipeline.service.PipelineService;
+import com.timiroom.domain.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -52,6 +53,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class KnowledgeGraphService {
 
+    private final ProjectService projectService;
     private final PipelineService pipelineService;
     private final ArtifactRevisionRepository revisionRepository;
     private final GithubPullRequestReviewRecordRepository reviewRecordRepository;
@@ -91,6 +93,16 @@ public class KnowledgeGraphService {
     /** "테이블A (1:N) 테이블B" 형태의 관계 서술 */
     private static final Pattern RELATION = Pattern.compile(
             "([A-Za-z_][A-Za-z0-9_]*)\\s*\\(\\s*([0-9NM]+\\s*:\\s*[0-9NM]+)\\s*\\)\\s*([A-Za-z_][A-Za-z0-9_]*)");
+
+    /**
+     * @param memberId 요청자. 이 프로젝트 사람이 맞는지 먼저 확인한다 —
+     *                 응답이 곧 명세 전체라 소속 확인 없이는 남의 프로젝트가 그대로 읽힌다.
+     */
+    @Transactional(readOnly = true)
+    public GraphResponse build(Long projectId, Long memberId) {
+        projectService.getById(projectId, memberId);
+        return build(projectId);
+    }
 
     @Transactional(readOnly = true)
     public GraphResponse build(Long projectId) {

--- a/src/main/java/com/timiroom/domain/pipeline/entity/ArtifactRevision.java
+++ b/src/main/java/com/timiroom/domain/pipeline/entity/ArtifactRevision.java
@@ -1,0 +1,47 @@
+package com.timiroom.domain.pipeline.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * 아티팩트 이전 버전 보관
+ *
+ * 문서를 수정하면 덮어쓰기 전의 내용을 여기에 남긴다.
+ * 무엇이 바뀌었는지 알아야 "이 변경이 어디에 영향을 주는지"를 계산할 수 있고,
+ * 그것이 이 서비스가 파는 정합성의 핵심이다.
+ *
+ * pipeline_artifact 테이블에 버전 행을 쌓지 않고 따로 두는 이유는,
+ * 기존 조회가 "종류별 최신 하나"를 전제로 짜여 있어 행이 늘면 그 전제가 깨지기 때문이다.
+ */
+@Entity
+@Table(name = "artifact_revision", indexes = {
+        @Index(name = "idx_revision_artifact", columnList = "artifact_id, version")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ArtifactRevision {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "revision_id")
+    private Long revisionId;
+
+    @Column(name = "artifact_id", nullable = false)
+    private Long artifactId;
+
+    /** 이 내용이 몇 번째 버전이었는지 */
+    @Column(nullable = false)
+    private int version;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/timiroom/domain/pipeline/entity/PipelineArtifact.java
+++ b/src/main/java/com/timiroom/domain/pipeline/entity/PipelineArtifact.java
@@ -37,8 +37,14 @@ public class PipelineArtifact {
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
+    /**
+     * 내용을 바꾸고 버전을 하나 올린다.
+     * 이전 내용은 호출하는 쪽에서 ArtifactRevision으로 옮겨 둔 뒤여야 한다 —
+     * 그래야 무엇이 바뀌었는지 나중에 비교할 수 있다.
+     */
     public void updateContent(String content) {
         this.content = content;
+        this.version += 1;
     }
 
     public enum ArtifactType {

--- a/src/main/java/com/timiroom/domain/pipeline/repository/ArtifactRevisionRepository.java
+++ b/src/main/java/com/timiroom/domain/pipeline/repository/ArtifactRevisionRepository.java
@@ -1,0 +1,12 @@
+package com.timiroom.domain.pipeline.repository;
+
+import com.timiroom.domain.pipeline.entity.ArtifactRevision;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ArtifactRevisionRepository extends JpaRepository<ArtifactRevision, Long> {
+
+    /** 이 아티팩트의 가장 최근 이전 버전 — 변경 비교의 기준이 된다 */
+    Optional<ArtifactRevision> findFirstByArtifactIdOrderByVersionDesc(Long artifactId);
+}

--- a/src/main/java/com/timiroom/domain/pipeline/service/PipelineService.java
+++ b/src/main/java/com/timiroom/domain/pipeline/service/PipelineService.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.timiroom.domain.notification.enums.NotificationReferenceType;
 import com.timiroom.domain.notification.service.NotificationService;
 import com.timiroom.domain.notification.enums.NotificationType;
+import com.timiroom.domain.pipeline.entity.ArtifactRevision;
 import com.timiroom.domain.pipeline.entity.PipelineArtifact;
 import com.timiroom.domain.pipeline.entity.PipelineExecution;
+import com.timiroom.domain.pipeline.repository.ArtifactRevisionRepository;
 import com.timiroom.domain.pipeline.repository.PipelineArtifactRepository;
 import com.timiroom.domain.pipeline.repository.PipelineExecutionRepository;
 import com.timiroom.domain.requirement.entity.Requirement;
@@ -33,6 +35,7 @@ public class PipelineService {
     private final RagPipelineClient ragPipelineClient;
     private final PipelineExecutionRepository executionRepository;
     private final PipelineArtifactRepository artifactRepository;
+    private final ArtifactRevisionRepository revisionRepository;
     private final RequirementService requirementService;
     private final NotificationService notificationService;
     private final ObjectMapper objectMapper;
@@ -214,13 +217,32 @@ public class PipelineService {
         return artifactRepository.findByExecutionIdOrderByArtifactType(executionId);
     }
 
+    /**
+     * 문서 내용을 수정한다.
+     *
+     * 덮어쓰기 전에 이전 내용을 이력으로 남긴다. 이 이력이 있어야
+     * "직전 대비 무엇이 바뀌었고 그 변경이 어디에 영향을 주는지"를 계산할 수 있다.
+     */
     @Transactional
     public void updateArtifact(Long artifactId, String content) {
         PipelineArtifact artifact = artifactRepository.findById(artifactId)
                 .orElseThrow(() -> new IllegalArgumentException("Artifact not found: " + artifactId));
+
+        // 내용이 그대로면 이력을 늘리지 않는다 — 저장 버튼만 눌러도 버전이 오르면 이력이 무의미해진다
+        if (content == null || content.equals(artifact.getContent())) {
+            return;
+        }
+
+        revisionRepository.save(ArtifactRevision.builder()
+                .artifactId(artifactId)
+                .version(artifact.getVersion())
+                .content(artifact.getContent())
+                .build());
+
         artifact.updateContent(content);
         artifactRepository.save(artifact);
-        log.info("Artifact 수정 | artifactId: {}", artifactId);
+        log.info("Artifact 수정 | artifactId: {}, version: {} → {}",
+                artifactId, artifact.getVersion() - 1, artifact.getVersion());
     }
 
     public List<PipelineArtifact> getLatestArtifactsByProject(Long projectId) {

--- a/src/test/java/com/timiroom/domain/graph/KnowledgeGraphServiceTest.java
+++ b/src/test/java/com/timiroom/domain/graph/KnowledgeGraphServiceTest.java
@@ -11,6 +11,7 @@ import com.timiroom.domain.pipeline.entity.ArtifactRevision;
 import com.timiroom.domain.pipeline.entity.PipelineArtifact;
 import com.timiroom.domain.pipeline.repository.ArtifactRevisionRepository;
 import com.timiroom.domain.pipeline.service.PipelineService;
+import com.timiroom.domain.project.service.ProjectService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 /**
  * 지식 그래프 연결 판정 검증.
@@ -38,6 +43,9 @@ class KnowledgeGraphServiceTest {
 
     @Mock
     ArtifactRevisionRepository revisionRepository;
+
+    @Mock
+    ProjectService projectService;
 
     @Mock
     GithubPullRequestReviewRecordRepository reviewRecordRepository;
@@ -76,7 +84,7 @@ class KnowledgeGraphServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new KnowledgeGraphService(pipelineService, revisionRepository,
+        service = new KnowledgeGraphService(projectService, pipelineService, revisionRepository,
                 reviewRecordRepository, projectRepoLinkRepository, new ObjectMapper());
     }
 
@@ -477,6 +485,31 @@ class KnowledgeGraphServiceTest {
             assertThat(n.change()).isNull();
             assertThat(n.impacted()).isFalse();
         });
+    }
+
+    @Test
+    @DisplayName("프로젝트 사람이 아니면 그래프를 내주지 않는다")
+    void 소속을_먼저_확인한다() {
+        // 응답에는 기능 목록·API 경로와 설명·테이블 컬럼·PR 제목이 모두 담긴다.
+        // 사실상 명세 전체라, 소속 확인 없이는 projectId만 바꿔 남의 프로젝트가 읽힌다.
+        given(projectService.getById(1L, 999L))
+                .willThrow(new SecurityException("프로젝트 접근 권한이 없습니다"));
+
+        assertThatThrownBy(() -> service.build(1L, 999L))
+                .isInstanceOf(SecurityException.class);
+
+        // 권한이 막혔으면 명세를 읽는 데까지 가서도 안 된다
+        then(pipelineService).should(never()).getLatestArtifactsByProject(anyLong());
+    }
+
+    @Test
+    @DisplayName("프로젝트 사람이면 그래프를 정상적으로 받는다")
+    void 소속이_확인되면_내준다() {
+        givenArtifacts();
+
+        GraphResponse graph = service.build(1L, 7L);
+
+        assertThat(graph.nodes()).isNotEmpty();
     }
 
     /* ══════════════════════════════════════

--- a/src/test/java/com/timiroom/domain/graph/KnowledgeGraphServiceTest.java
+++ b/src/test/java/com/timiroom/domain/graph/KnowledgeGraphServiceTest.java
@@ -1,0 +1,634 @@
+package com.timiroom.domain.graph;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.timiroom.domain.github.GithubPullRequestReviewRecord;
+import com.timiroom.domain.github.GithubPullRequestReviewRecordRepository;
+import com.timiroom.domain.github.ProjectRepoLink;
+import com.timiroom.domain.github.ProjectRepoLinkRepository;
+import com.timiroom.domain.graph.dto.GraphResponse;
+import com.timiroom.domain.graph.service.KnowledgeGraphService;
+import com.timiroom.domain.pipeline.entity.ArtifactRevision;
+import com.timiroom.domain.pipeline.entity.PipelineArtifact;
+import com.timiroom.domain.pipeline.repository.ArtifactRevisionRepository;
+import com.timiroom.domain.pipeline.service.PipelineService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * 지식 그래프 연결 판정 검증.
+ *
+ * 실제 파이프라인이 만들어 낸 명세와 같은 모양의 데이터를 쓴다.
+ * 한국어 기능 문구와 영어 경로·테이블명을 잇는 부분이 이 기능의 핵심이라
+ * 그 판정이 의도대로 도는지를 중심으로 확인한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class KnowledgeGraphServiceTest {
+
+    @Mock
+    PipelineService pipelineService;
+
+    @Mock
+    ArtifactRevisionRepository revisionRepository;
+
+    @Mock
+    GithubPullRequestReviewRecordRepository reviewRecordRepository;
+
+    @Mock
+    ProjectRepoLinkRepository projectRepoLinkRepository;
+
+    KnowledgeGraphService service;
+
+    private static final String FEATURES = """
+            ["리뷰 신뢰도 점수", "검증 리뷰 목록 조회", "리뷰 작성", "포인트 정산"]
+            """;
+
+    private static final String API_SPEC = """
+            {
+              "endpoints": [
+                {"method":"GET","path":"/api/v1/reviews","description":"검증된 리뷰 목록을 조회한다","authRequired":false},
+                {"method":"POST","path":"/api/v1/reviews","description":"리뷰 작성","authRequired":true},
+                {"method":"GET","path":"/api/v1/reviews/{reviewId}/score","description":"리뷰 신뢰도 점수 조회","authRequired":false},
+                {"method":"GET","path":"/api/v1/banners","description":"홍보 배너 조회","authRequired":false}
+              ]
+            }
+            """;
+
+    private static final String DB_SCHEMA = """
+            {
+              "tables": [
+                {"name":"reviews","columns":[{"name":"id"},{"name":"member_id"},{"name":"content"}]},
+                {"name":"review_scores","columns":[{"name":"id"},{"name":"review_id"},{"name":"score"}]},
+                {"name":"members","columns":[{"name":"id"},{"name":"nickname"}]},
+                {"name":"audit_logs","columns":[{"name":"id"},{"name":"message"}]}
+              ],
+              "relationships": ["members (1:N) reviews", "reviews (1:N) review_scores"]
+            }
+            """;
+
+    @BeforeEach
+    void setUp() {
+        service = new KnowledgeGraphService(pipelineService, revisionRepository,
+                reviewRecordRepository, projectRepoLinkRepository, new ObjectMapper());
+    }
+
+    private void givenArtifacts() {
+        given(pipelineService.getLatestArtifactsByProject(1L)).willReturn(List.of(
+                artifact(PipelineArtifact.ArtifactType.FEATURE_LIST, FEATURES),
+                artifact(PipelineArtifact.ArtifactType.API_SPEC, API_SPEC),
+                artifact(PipelineArtifact.ArtifactType.DB_SCHEMA, DB_SCHEMA)
+        ));
+    }
+
+    private PipelineArtifact artifact(PipelineArtifact.ArtifactType type, String content) {
+        return PipelineArtifact.builder()
+                .artifactId((long) (type.ordinal() + 1))
+                .executionId(1L)
+                .artifactType(type)
+                .content(content)
+                .version(2)
+                .build();
+    }
+
+    @Test
+    @DisplayName("기능 문구에 조사가 붙어도 같은 대상을 말하는 API와 이어진다")
+    void 기능과_API를_연결한다() {
+        givenArtifacts();
+
+        GraphResponse graph = service.build(1L);
+
+        // "검증 리뷰 목록 조회" ↔ "검증된 리뷰 목록을 조회한다" — 조사 차이를 넘어 연결돼야 한다
+        assertThat(edgeExists(graph, "feature:검증 리뷰 목록 조회", "api:GET:/api/v1/reviews")).isTrue();
+        assertThat(edgeExists(graph, "feature:리뷰 신뢰도 점수", "api:GET:/api/v1/reviews/{reviewId}/score")).isTrue();
+        assertThat(edgeExists(graph, "feature:리뷰 작성", "api:POST:/api/v1/reviews")).isTrue();
+    }
+
+    @Test
+    @DisplayName("짧은 기능명은 낱말이 하나만 겹쳐서는 이어지지 않는다")
+    void 짧은_기능명은_전부_일치해야_한다() {
+        // 실제 명세에서 나온 사례다. "쿠폰 발급"의 두 낱말 중 `발급` 하나가
+        // "로그인: JWT 발급"에 걸려 곧바로 50%가 되면서 엉뚱하게 이어졌다.
+        String apis = """
+                {"endpoints":[
+                  {"method":"POST","path":"/api/v1/auth/login","description":"로그인: 사용자 인증 및 JWT 발급","authRequired":false},
+                  {"method":"POST","path":"/api/v1/coupons","description":"쿠폰 발급: 신규 가입자에게 쿠폰 지급","authRequired":true}
+                ]}
+                """;
+
+        given(pipelineService.getLatestArtifactsByProject(1L)).willReturn(List.of(
+                artifact(PipelineArtifact.ArtifactType.FEATURE_LIST, """
+                        ["로그인", "쿠폰 발급"]"""),
+                artifact(PipelineArtifact.ArtifactType.API_SPEC, apis),
+                artifact(PipelineArtifact.ArtifactType.DB_SCHEMA, """
+                        {"tables":[]}""")));
+
+        GraphResponse graph = service.build(1L);
+
+        // `발급` 하나만 겹치는 로그인 API와는 이어지지 않는다
+        assertThat(edgeExists(graph, "feature:쿠폰 발급", "api:POST:/api/v1/auth/login")).isFalse();
+        // 두 낱말이 모두 나오는 쪽과는 이어진다
+        assertThat(edgeExists(graph, "feature:쿠폰 발급", "api:POST:/api/v1/coupons")).isTrue();
+        // 한 낱말짜리 기능도 그대로 이어져야 한다
+        assertThat(edgeExists(graph, "feature:로그인", "api:POST:/api/v1/auth/login")).isTrue();
+    }
+
+    @Test
+    @DisplayName("거의 모든 설명에 나오는 낱말은 연결의 근거로 세지 않는다")
+    void 흔한_낱말은_근거가_되지_않는다() {
+        // 실제 명세에서 나온 사례다. `사용자`는 아홉 중 여섯에 나와 어느 API인지
+        // 조금도 좁혀 주지 못하는데, "사용자 정보 조회"가 그 낱말에 기대어
+        // 엉뚱하게 식성 프로필 API까지 이어졌다.
+        String apis = """
+                {"endpoints":[
+                  {"method":"GET","path":"/api/v1/users/me","description":"사용자 정보 조회: 현재 로그인된 사용자 정보 반환","authRequired":true},
+                  {"method":"GET","path":"/api/v1/food-profiles","description":"식성 프로필: 등록된 사용자별 선호 음식 정보 확인","authRequired":true},
+                  {"method":"POST","path":"/api/v1/food-profiles","description":"식성 프로필: 사용자별 선호 등록","authRequired":true},
+                  {"method":"PUT","path":"/api/v1/food-profiles/{userId}","description":"식성 프로필: 사용자별 선호 정보 수정","authRequired":true},
+                  {"method":"POST","path":"/api/v1/auth/register","description":"회원가입: 사용자 계정 생성","authRequired":false},
+                  {"method":"POST","path":"/api/v1/auth/login","description":"로그인: 사용자 인증 및 토큰 발급","authRequired":false},
+                  {"method":"PUT","path":"/api/v1/users/profile","description":"프로필 수정: 사용자 프로필 정보 업데이트","authRequired":true},
+                  {"method":"POST","path":"/api/v1/delivery-estimations","description":"배달 시간 예측: 도착 시간 예측 요청","authRequired":true},
+                  {"method":"GET","path":"/api/v1/weekly-reports","description":"주간 추천 리포트: 주간 식사 패턴 분석","authRequired":true}
+                ]}
+                """;
+
+        given(pipelineService.getLatestArtifactsByProject(1L)).willReturn(List.of(
+                artifact(PipelineArtifact.ArtifactType.FEATURE_LIST, """
+                        ["사용자 정보 조회", "식성 프로필", "배달 시간 예측"]"""),
+                artifact(PipelineArtifact.ArtifactType.API_SPEC, apis),
+                artifact(PipelineArtifact.ArtifactType.DB_SCHEMA, """
+                        {"tables":[]}""")));
+
+        GraphResponse graph = service.build(1L);
+
+        // 흔한 `사용자`를 빼면 남는 건 `정보`·`조회`. 둘 다 나오는 곳에만 이어진다.
+        assertThat(edgeExists(graph, "feature:사용자 정보 조회", "api:GET:/api/v1/users/me")).isTrue();
+        assertThat(edgeExists(graph, "feature:사용자 정보 조회", "api:GET:/api/v1/food-profiles")).isFalse();
+        assertThat(edgeExists(graph, "feature:사용자 정보 조회", "api:PUT:/api/v1/users/profile")).isFalse();
+
+        // 변별력 있는 낱말로 이루어진 기능은 그대로 이어져야 한다
+        assertThat(edgeExists(graph, "feature:식성 프로필", "api:POST:/api/v1/food-profiles")).isTrue();
+        assertThat(edgeExists(graph, "feature:배달 시간 예측", "api:POST:/api/v1/delivery-estimations")).isTrue();
+    }
+
+    @Test
+    @DisplayName("엔드포인트가 얼마 없으면 낱말 빈도를 따지지 않는다")
+    void 명세가_작으면_빈도를_따지지_않는다() {
+        // 두 개짜리 명세에서는 한 번만 나와도 곧바로 50%라, 빈도가 변별력을 말해 주지 못한다.
+        // 이때 흔함을 따지면 멀쩡한 낱말이 통째로 버려진다.
+        givenArtifacts();   // 엔드포인트 4개
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(edgeExists(graph, "feature:검증 리뷰 목록 조회", "api:GET:/api/v1/reviews")).isTrue();
+        assertThat(edgeExists(graph, "feature:리뷰 작성", "api:POST:/api/v1/reviews")).isTrue();
+    }
+
+    @Test
+    @DisplayName("같은 엔드포인트가 명세에 두 번 적혀 있으면 합치고 몇 번인지 남긴다")
+    void 중복_엔드포인트를_합친다() {
+        // 실제 명세에 GET /api/v2/food-menu/{category}가 두 번 들어 있었다.
+        // 합치지 않으면 id가 같은 노드가 둘 생기고 화면이 뒤엣것을 말없이 버린다.
+        String apis = """
+                {"endpoints":[
+                  {"method":"GET","path":"/api/v1/reviews","description":"검증된 리뷰 목록을 조회한다","authRequired":false},
+                  {"method":"GET","path":"/api/v1/reviews","description":"리뷰 목록 조회","authRequired":false}
+                ]}
+                """;
+
+        given(pipelineService.getLatestArtifactsByProject(1L)).willReturn(List.of(
+                artifact(PipelineArtifact.ArtifactType.FEATURE_LIST, """
+                        ["검증 리뷰 목록 조회"]"""),
+                artifact(PipelineArtifact.ArtifactType.API_SPEC, apis),
+                artifact(PipelineArtifact.ArtifactType.DB_SCHEMA, """
+                        {"tables":[]}""")));
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(graph.summary().apiCount()).isEqualTo(1);
+        assertThat(graph.nodes().stream().map(GraphResponse.Node::id).distinct().count())
+                .isEqualTo(graph.nodes().size());
+        assertThat(nodeById(graph, "api:GET:/api/v1/reviews").meta())
+                .extracting("notice").asString().contains("2번");
+        // 먼저 적힌 설명이 남는다
+        assertThat(nodeById(graph, "api:GET:/api/v1/reviews").meta())
+                .extracting("description").asString().contains("검증된");
+    }
+
+    @Test
+    @DisplayName("API 경로의 리소스명으로 테이블을 찾고, 같은 계열 하위 테이블도 함께 잇는다")
+    void API와_테이블을_연결한다() {
+        givenArtifacts();
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(edgeExists(graph, "api:GET:/api/v1/reviews", "table:reviews")).isTrue();
+        // reviews 경로는 review_scores 같은 같은 계열 테이블도 다룬다고 본다
+        assertThat(edgeExists(graph, "api:GET:/api/v1/reviews", "table:review_scores")).isTrue();
+        // 무관한 테이블까지 잇지는 않는다
+        assertThat(edgeExists(graph, "api:GET:/api/v1/reviews", "table:members")).isFalse();
+    }
+
+    @Test
+    @DisplayName("경로의 하이픈과 테이블의 밑줄은 같은 낱말로 본다")
+    void 구분자가_달라도_같은_리소스로_본다() {
+        // 실제 명세가 이렇게 생겼다 — REST는 하이픈, DB는 밑줄이 양쪽의 관례다.
+        // 글자만 비교하면 멀쩡한 연결이 통째로 "설계 구멍"으로 잘못 보고된다.
+        String apis = """
+                {"endpoints":[
+                  {"method":"GET","path":"/api/v1/food-profiles","description":"식성 프로필 조회","authRequired":true},
+                  {"method":"GET","path":"/api/v2/food-menu/{category}","description":"간편 탐색","authRequired":true}
+                ]}
+                """;
+        String schema = """
+                {"tables":[
+                  {"name":"food_profiles","columns":[{"name":"id"},{"name":"user_id"}]},
+                  {"name":"food_menus","columns":[{"name":"id"},{"name":"category"}]}
+                ]}
+                """;
+
+        given(pipelineService.getLatestArtifactsByProject(1L)).willReturn(List.of(
+                artifact(PipelineArtifact.ArtifactType.FEATURE_LIST, """
+                        ["식성 프로필", "간편 탐색"]"""),
+                artifact(PipelineArtifact.ArtifactType.API_SPEC, apis),
+                artifact(PipelineArtifact.ArtifactType.DB_SCHEMA, schema)));
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(edgeExists(graph, "api:GET:/api/v1/food-profiles", "table:food_profiles")).isTrue();
+        assertThat(edgeExists(graph, "api:GET:/api/v2/food-menu/{category}", "table:food_menus")).isTrue();
+        assertThat(graph.summary().orphanTables()).isZero();
+
+        // 같은 도메인으로도 묶여야 한다 — food-profiles와 food_menus 모두 food 묶음
+        String group = nodeById(graph, "table:food_profiles").parent();
+        assertThat(group).isNotNull();
+        assertThat(nodeById(graph, "table:food_menus").parent()).isEqualTo(group);
+        assertThat(nodeById(graph, "api:GET:/api/v1/food-profiles").parent()).isEqualTo(group);
+    }
+
+    @Test
+    @DisplayName("관계 서술과 외래키 컬럼에서 테이블 간 참조를 뽑는다")
+    void 테이블_간_참조를_연결한다() {
+        givenArtifacts();
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(edgeExists(graph, "table:members", "table:reviews")).isTrue();
+        assertThat(edgeExists(graph, "table:reviews", "table:review_scores")).isTrue();
+        // member_id 컬럼으로도 members를 참조한다고 본다
+        assertThat(hasEdge(graph, "table:reviews", "table:members", "REFERENCES")).isTrue();
+    }
+
+    @Test
+    @DisplayName("어느 쪽과도 이어지지 않은 노드를 설계 구멍으로 표시한다")
+    void 고아_노드를_찾아낸다() {
+        givenArtifacts();
+
+        GraphResponse graph = service.build(1L);
+
+        // 기능 목록에 근거가 없는 API
+        assertThat(nodeById(graph, "api:GET:/api/v1/banners").orphan()).isTrue();
+        // 구현하는 API가 없는 기능
+        assertThat(nodeById(graph, "feature:포인트 정산").orphan()).isTrue();
+        // 쓰는 API가 없는 테이블
+        assertThat(nodeById(graph, "table:audit_logs").orphan()).isTrue();
+
+        // members는 reviews와 외래키로 이어져 있지만 이 테이블을 다루는 API가 없다.
+        // 같은 계층끼리의 연결은 고아 판정을 풀어주지 않는다 —
+        // 저장만 되고 아무도 꺼내 쓰지 않는 테이블이야말로 설계 구멍이기 때문이다.
+        assertThat(nodeById(graph, "table:members").orphan()).isTrue();
+
+        // 정상적으로 이어진 노드는 표시되지 않는다
+        assertThat(nodeById(graph, "api:GET:/api/v1/reviews").orphan()).isFalse();
+
+        assertThat(graph.summary().orphanApis()).isEqualTo(1);
+        assertThat(graph.summary().orphanFeatures()).isEqualTo(1);
+        assertThat(graph.summary().orphanTables()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("같은 리소스를 다루는 노드는 하나의 도메인 그룹으로 묶인다")
+    void 도메인별로_묶는다() {
+        givenArtifacts();
+
+        GraphResponse graph = service.build(1L);
+
+        String reviewGroup = nodeById(graph, "table:reviews").parent();
+        assertThat(reviewGroup).isNotNull();
+        // reviews · review_scores · /api/v1/reviews 는 같은 그룹이어야 한다
+        assertThat(nodeById(graph, "table:review_scores").parent()).isEqualTo(reviewGroup);
+        assertThat(nodeById(graph, "api:GET:/api/v1/reviews").parent()).isEqualTo(reviewGroup);
+        // 다른 리소스는 다른 그룹
+        assertThat(nodeById(graph, "table:members").parent()).isNotEqualTo(reviewGroup);
+    }
+
+    @Test
+    @DisplayName("혼자 남는 도메인은 묶지 않는다")
+    void 구성원이_하나뿐인_묶음은_만들지_않는다() {
+        givenArtifacts();
+
+        GraphResponse graph = service.build(1L);
+
+        // audit_logs 하나뿐인 audit은 묶음이 되지 않는다.
+        // 구성원이 하나면 화면에 라벨만 하나 더 뜰 뿐 아무것도 알려주지 않는다.
+        assertThat(graph.nodes()).noneMatch(n -> "group:audit".equals(n.id()));
+        assertThat(nodeById(graph, "table:audit_logs").parent()).isNull();
+
+        // 여럿이 모인 묶음은 그대로 남는다 — reviews·review_scores·/reviews
+        assertThat(graph.nodes()).anyMatch(n -> "group:review".equals(n.id()));
+        assertThat(nodeById(graph, "table:reviews").parent()).isEqualTo("group:review");
+    }
+
+    @Test
+    @DisplayName("명세가 아직 없는 프로젝트는 빈 그래프를 돌려준다")
+    void 아티팩트가_없으면_빈_그래프() {
+        given(pipelineService.getLatestArtifactsByProject(9L)).willReturn(List.of());
+
+        GraphResponse graph = service.build(9L);
+
+        assertThat(graph.nodes()).isEmpty();
+        assertThat(graph.edges()).isEmpty();
+        assertThat(graph.summary().featureCount()).isZero();
+    }
+
+    /* ══════════════════════════════════════
+       변경 영향 — 이 기능의 핵심
+    ══════════════════════════════════════ */
+
+    @Test
+    @DisplayName("테이블에서 컬럼이 빠지면 그 테이블을 쓰는 API까지 확인 대상이 된다")
+    void 변경이_이어진_곳까지_퍼진다() {
+        // 직전 버전에는 reviews에 content 컬럼이 있었다
+        String beforeSchema = DB_SCHEMA;
+        // 지금은 content가 빠졌다 — 이 테이블을 읽어 쓰던 API가 깨질 수 있다
+        String afterSchema = DB_SCHEMA.replace("""
+                {"name":"reviews","columns":[{"name":"id"},{"name":"member_id"},{"name":"content"}]}""",
+                """
+                {"name":"reviews","columns":[{"name":"id"},{"name":"member_id"}]}""");
+
+        given(pipelineService.getLatestArtifactsByProject(1L)).willReturn(List.of(
+                artifact(PipelineArtifact.ArtifactType.FEATURE_LIST, FEATURES),
+                artifact(PipelineArtifact.ArtifactType.API_SPEC, API_SPEC),
+                artifact(PipelineArtifact.ArtifactType.DB_SCHEMA, afterSchema)
+        ));
+        givenRevision(PipelineArtifact.ArtifactType.DB_SCHEMA, beforeSchema);
+
+        GraphResponse graph = service.build(1L);
+
+        // 직접 바뀐 것
+        assertThat(nodeById(graph, "table:reviews").change()).isEqualTo("MODIFIED");
+
+        // 그 테이블을 쓰는 API는 스스로 바뀌지 않았지만 확인이 필요하다
+        assertThat(nodeById(graph, "api:GET:/api/v1/reviews").impacted()).isTrue();
+        assertThat(nodeById(graph, "api:POST:/api/v1/reviews").impacted()).isTrue();
+
+        // 그 API를 낳은 기능까지 이어져 올라간다
+        assertThat(nodeById(graph, "feature:리뷰 작성").impacted()).isTrue();
+
+        // 무관한 쪽은 건드리지 않는다
+        assertThat(nodeById(graph, "api:GET:/api/v1/banners").impacted()).isFalse();
+
+        assertThat(graph.summary().changedCount()).isEqualTo(1);
+        assertThat(graph.summary().impactedCount()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("영향은 두 걸음까지만 번져 옆 도메인으로 새지 않는다")
+    void 영향은_두_걸음까지만_번진다() {
+        // members 테이블이 바뀐 상황. members는 reviews와 외래키로 이어져 있고
+        // reviews는 다시 여러 API·기능으로 이어진다. 끝까지 퍼뜨리면 온 그래프가 물든다.
+        String beforeSchema = DB_SCHEMA;
+        String afterSchema = DB_SCHEMA.replace("""
+                {"name":"members","columns":[{"name":"id"},{"name":"nickname"}]}""",
+                """
+                {"name":"members","columns":[{"name":"id"}]}""");
+
+        given(pipelineService.getLatestArtifactsByProject(1L)).willReturn(List.of(
+                artifact(PipelineArtifact.ArtifactType.FEATURE_LIST, FEATURES),
+                artifact(PipelineArtifact.ArtifactType.API_SPEC, API_SPEC),
+                artifact(PipelineArtifact.ArtifactType.DB_SCHEMA, afterSchema)));
+        givenRevision(PipelineArtifact.ArtifactType.DB_SCHEMA, beforeSchema);
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(nodeById(graph, "table:members").change()).isEqualTo("MODIFIED");
+
+        // 한 걸음: 외래키로 이어진 reviews
+        assertThat(nodeById(graph, "table:reviews").impacted()).isTrue();
+
+        // 세 걸음 거리인 기능까지는 가지 않는다.
+        // members → reviews(1) → GET /reviews(2) → 검증 리뷰 목록 조회(3)
+        assertThat(nodeById(graph, "feature:검증 리뷰 목록 조회").impacted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("기능을 새로 넣으면 추가로 표시된다")
+    void 추가된_항목을_찾아낸다() {
+        String beforeFeatures = """
+                ["리뷰 신뢰도 점수", "검증 리뷰 목록 조회", "포인트 정산"]
+                """;
+
+        givenArtifacts();
+        givenRevision(PipelineArtifact.ArtifactType.FEATURE_LIST, beforeFeatures);
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(nodeById(graph, "feature:리뷰 작성").change()).isEqualTo("ADDED");
+        assertThat(nodeById(graph, "feature:포인트 정산").change()).isNull();
+    }
+
+    @Test
+    @DisplayName("사라진 항목도 노드로 남겨 무엇이 없어졌는지 보이게 한다")
+    void 삭제된_항목을_남긴다() {
+        String beforeApis = API_SPEC.replace("""
+                {"method":"GET","path":"/api/v1/banners","description":"홍보 배너 조회","authRequired":false}""",
+                """
+                {"method":"GET","path":"/api/v1/banners","description":"홍보 배너 조회","authRequired":false},
+                {"method":"DELETE","path":"/api/v1/reviews/{reviewId}","description":"리뷰 삭제","authRequired":true}""");
+
+        givenArtifacts();
+        givenRevision(PipelineArtifact.ArtifactType.API_SPEC, beforeApis);
+
+        GraphResponse graph = service.build(1L);
+
+        GraphResponse.Node gone = nodeById(graph, "api:DELETE:/api/v1/reviews/{reviewId}");
+        assertThat(gone.change()).isEqualTo("REMOVED");
+        assertThat(gone.label()).contains("DELETE");
+    }
+
+    @Test
+    @DisplayName("수정된 적이 없으면 변경 표시가 생기지 않는다")
+    void 이력이_없으면_변경도_없다() {
+        givenArtifacts();   // 이력 없음
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(graph.summary().changedCount()).isZero();
+        assertThat(graph.summary().impactedCount()).isZero();
+        assertThat(graph.nodes()).allSatisfy(n -> {
+            assertThat(n.change()).isNull();
+            assertThat(n.impacted()).isFalse();
+        });
+    }
+
+    /* ══════════════════════════════════════
+       코드(PR) → 명세
+    ══════════════════════════════════════ */
+
+    @Test
+    @DisplayName("PR이 건드린 경로·테이블로 코드가 명세에 이어지고, 그 위 기능까지 영향이 올라간다")
+    void PR을_명세에_연결한다() {
+        givenArtifacts();
+        givenPullRequest(7, "리뷰 작성 검증 보강", """
+                {"apis":["/api/v1/reviews"],"tables":["reviews"],
+                 "files":["src/main/java/.../ReviewController.java"]}""");
+
+        GraphResponse graph = service.build(1L);
+
+        String prId = "pr:100:7";
+        assertThat(hasEdge(graph, prId, "api:GET:/api/v1/reviews", "CHANGES")).isTrue();
+        assertThat(hasEdge(graph, prId, "api:POST:/api/v1/reviews", "CHANGES")).isTrue();
+        assertThat(hasEdge(graph, prId, "table:reviews", "CHANGES")).isTrue();
+
+        // 코드가 닿은 API를 거쳐 그것을 구현하는 기능까지 확인 대상이 된다.
+        // "이 PR을 머지하면 어떤 요구사항이 걸리는가"에 대한 답이 여기서 나온다.
+        assertThat(nodeById(graph, "feature:리뷰 작성").impacted()).isTrue();
+        assertThat(nodeById(graph, "feature:검증 리뷰 목록 조회").impacted()).isTrue();
+
+        // 손대지 않은 쪽은 조용해야 한다
+        assertThat(nodeById(graph, "api:GET:/api/v1/banners").impacted()).isFalse();
+
+        assertThat(graph.summary().prCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("코드에서 건진 경로가 명세보다 짧아도 같은 엔드포인트로 본다")
+    void 부분_경로도_같은_엔드포인트로_본다() {
+        givenArtifacts();
+        // 컨트롤러의 @RequestMapping만 diff에 잡힌 상황 — 메서드 매핑은 안 바뀌었다
+        givenPullRequest(8, "점수 계산 수정", """
+                {"apis":["/api/v1/reviews"],"tables":[],"files":["ScoreService.java"]}""");
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(hasEdge(graph, "pr:100:8", "api:GET:/api/v1/reviews/{reviewId}/score", "CHANGES")).isTrue();
+    }
+
+    @Test
+    @DisplayName("명세에 걸리는 접점이 없는 PR은 그래프에 올리지 않는다")
+    void 접점이_없는_PR은_제외한다() {
+        givenArtifacts();
+        givenPullRequest(9, "README 오타 수정", """
+                {"apis":[],"tables":[],"files":["README.md"]}""");
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(graph.summary().prCount()).isZero();
+        assertThat(graph.nodes()).noneMatch(n -> "pr".equals(n.type()));
+    }
+
+    @Test
+    @DisplayName("머지되거나 닫힌 PR은 그래프에서 내린다")
+    void 닫힌_PR은_제외한다() {
+        givenArtifacts();
+        givenPullRequest(42, "리뷰 작성 검증 보강", """
+                {"apis":["/api/v1/reviews"],"tables":["reviews"],"files":["ReviewController.java"]}""",
+                "closed");
+
+        GraphResponse graph = service.build(1L);
+
+        // 그래프의 PR은 "지금 진행 중"이라는 뜻이다. 끝난 작업이 남으면
+        // 몇 달 전 변경까지 영향 표시가 켜진 채로 쌓인다.
+        assertThat(graph.summary().prCount()).isZero();
+        assertThat(graph.nodes()).noneMatch(n -> "pr".equals(n.type()));
+        // 그 PR이 켜 두었던 영향 표시도 함께 꺼져야 한다
+        assertThat(nodeById(graph, "feature:리뷰 작성").impacted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("레포가 연결되지 않은 프로젝트는 PR 조회를 시도하지 않는다")
+    void 레포가_없으면_PR도_없다() {
+        givenArtifacts();
+        given(projectRepoLinkRepository.findByProjectId(1L)).willReturn(List.of());
+
+        GraphResponse graph = service.build(1L);
+
+        assertThat(graph.summary().prCount()).isZero();
+    }
+
+    /* ── 검사 도우미 ── */
+
+    private void givenPullRequest(int pullNumber, String title, String touchedJson) {
+        givenPullRequest(pullNumber, title, touchedJson, "open");
+    }
+
+    /** 레포 하나가 연결돼 있고 그 레포에 검사를 마친 PR이 하나 있는 상황을 꾸민다 */
+    private void givenPullRequest(int pullNumber, String title, String touchedJson, String state) {
+        given(projectRepoLinkRepository.findByProjectId(1L)).willReturn(List.of(
+                ProjectRepoLink.builder().projectId(1L).githubRepoId(100L).build()));
+
+        given(reviewRecordRepository.findByProjectIdAndGithubRepoIdIn(1L, List.of(100L))).willReturn(List.of(
+                GithubPullRequestReviewRecord.builder()
+                        .projectId(1L)
+                        .githubRepoId(100L)
+                        .pullNumber(pullNumber)
+                        .headSha("abc1234")
+                        .pullTitle(title)
+                        .pullUrl("https://github.com/team/repo/pull/" + pullNumber)
+                        .pullState(state)
+                        .touchedJson(touchedJson)
+                        .score(75)
+                        .evaluator("PYTHON_EXAONE")
+                        .findingsJson("""
+                                [{"severity":"WARNING","area":"API 명세","message":"확인 필요"}]""")
+                        .build()));
+    }
+
+
+    /**
+     * 해당 문서에만 직전 버전이 있었던 것으로 꾸민다.
+     * 서비스는 문서 세 종류 모두의 이력을 찾아보므로 나머지는 "이력 없음"으로 명시해 둔다.
+     */
+    private void givenRevision(PipelineArtifact.ArtifactType type, String previousContent) {
+        for (PipelineArtifact.ArtifactType t : List.of(
+                PipelineArtifact.ArtifactType.FEATURE_LIST,
+                PipelineArtifact.ArtifactType.API_SPEC,
+                PipelineArtifact.ArtifactType.DB_SCHEMA)) {
+
+            long artifactId = t.ordinal() + 1;
+            given(revisionRepository.findFirstByArtifactIdOrderByVersionDesc(artifactId))
+                    .willReturn(t == type
+                            ? java.util.Optional.of(ArtifactRevision.builder()
+                                    .artifactId(artifactId)
+                                    .version(1)
+                                    .content(previousContent)
+                                    .build())
+                            : java.util.Optional.empty());
+        }
+    }
+
+    private boolean edgeExists(GraphResponse graph, String source, String target) {
+        return graph.edges().stream()
+                .anyMatch(e -> e.source().equals(source) && e.target().equals(target));
+    }
+
+    private boolean hasEdge(GraphResponse graph, String source, String target, String type) {
+        return graph.edges().stream()
+                .anyMatch(e -> e.source().equals(source) && e.target().equals(target) && e.type().equals(type));
+    }
+
+    private GraphResponse.Node nodeById(GraphResponse graph, String id) {
+        return graph.nodes().stream()
+                .filter(n -> n.id().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("노드를 찾을 수 없습니다: " + id));
+    }
+}


### PR DESCRIPTION
## 무엇

명세 세 벌(기획서·API·DB)과 PR 변경 내역을 읽어 서로 어떻게 얽혀 있는지 계산하고, 무언가 바뀌었을 때 그 여파가 어디까지 가는지 드러냅니다.

`GET /api/v1/projects/{projectId}/graph`

## 왜 저장하지 않는가

그래프 전용 저장소를 두지 않고 요청 시점에 아티팩트에서 매번 계산합니다. Neo4j도 쓰지 않습니다.

저장해 두면 명세는 바뀌었는데 그래프는 옛것을 들고 있는 순간이 생깁니다. 정합성을 다루는 기능이 스스로 정합성을 깨서는 안 된다고 보았습니다.

## 연결 규칙

| 관계 | 판단 근거 |
|---|---|
| 기능 → API | 설명·경로에 기능의 핵심 낱말이 얼마나 나오는지 |
| API → 테이블 | 경로의 리소스명과 테이블명 대조 |
| 테이블 → 테이블 | `relationships` 서술과 외래키 컬럼 |
| **PR → API·테이블** | 정합성 검사 때 diff에서 뽑아 둔 접점 |

마지막 규칙이 코드를 기획에 잇습니다. PR을 고르면 그 코드가 닿는 API를 거쳐 그것을 구현하는 요구사항까지 선이 이어집니다.

접점은 검사 시점에 `touched_json`으로 저장합니다. 그래프는 요청마다 계산되므로 그때 GitHub에 다시 물으면 호출 한도에 걸립니다. 판단 근거는 **정합성 검사가 쓰는 정규식을 그대로** 써서, 리뷰는 통과인데 그래프에는 선이 없는 어긋남이 생기지 않게 했습니다.

## 변경 감지와 영향 전파

- 명세를 수정하면 직전 내용을 `artifact_revision`에 남기고 지금과 견줍니다
- 사라진 항목은 따로 노드로 남깁니다 — 무엇이 없어졌는지가 영향 확인에서 가장 중요한 정보입니다
- 영향은 **양방향**으로 퍼집니다. 테이블이 바뀌면 그것을 쓰는 API가, 기능이 바뀌면 그것을 구현한 API가 영향을 받습니다
- 다만 **두 걸음까지만**. 세 계층이라 두 걸음이면 위아래 끝에 닿고, 그 이상은 외래키를 타고 옆 도메인으로 새어 신호가 소음이 됩니다

머지되거나 닫힌 PR은 그래프에서 내립니다(`pull_request.closed` 웹훅 처리 추가). 여기 있는 PR은 "지금 진행 중"이라는 뜻이어야 하며, 끝난 작업이 남으면 몇 달 전 변경까지 영향 표시가 켜진 채 쌓입니다.

## 실제 운영 명세로 검증하며 잡은 것

손으로 만든 테스트 픽스처로는 하나도 드러나지 않던 것들입니다. 운영 프로젝트 1의 실제 API 명세(엔드포인트 14개)를 넣고 나서야 나왔습니다.

1. **REST 경로는 하이픈, DB 테이블은 밑줄** — 구분자를 맞추지 않아 `/food-profiles` ↔ `food_profiles`가 어긋났습니다. 테이블 8개 중 **6개**가 설계 구멍으로 잘못 보고됐습니다
2. **영향 무제한 전파** — 컬럼 하나 늘렸는데 43개 중 23개가 "확인 필요"로 켜졌습니다. 전부 빨간불이면 아무것도 빨간불이 아닙니다
3. **흔한 낱말** — `사용자`가 13개 설명 중 7개에 나와 무관한 API가 이어졌습니다. 명세 안에서 문서 빈도가 높은 낱말은 변별력이 없으므로 세지 않습니다
4. **짧은 기능명** — 두 낱말짜리는 하나만 겹쳐도 곧바로 절반이 되어 뚫렸습니다
5. **중복 엔드포인트** — 같은 method·path가 두 번 적힌 명세에서 노드 id가 겹쳐 화면이 하나를 말없이 버렸습니다. 합치고 몇 번 적혔는지를 남깁니다

## 스키마 변경

`github_pull_request_review_record`에 컬럼 4개 추가 (`pull_title`, `pull_url`, `pull_state`, `touched_json`), `artifact_revision` 테이블 신규. `ddl-auto: update`로 자동 반영됩니다.

## 테스트

지식 그래프 **22개** 추가. 전체 스위트 **86개 통과**, 기존 `PullRequestConsistencyServiceTest` 13개 포함 실패 0.

## 리뷰 봐주셨으면 하는 곳

- **연결 판정 임계값** — `FEATURE_MATCH_RATIO 0.5`, `GENERIC_TOKEN_RATIO 0.4`, `MIN_CORPUS_FOR_TOKEN_FREQUENCY 8`, `MAX_IMPACT_DEPTH 2`. 실제 명세 한 벌로 맞춘 값이라 다른 프로젝트에서 어떨지 확인이 필요합니다
- **PR 접점을 영향 출발점에 포함한 것** — 열린 PR이 많은 프로젝트에서는 화면이 온통 주황이 될 수 있습니다. 지금은 이게 맞다고 보았지만, 시끄러우면 토글로 뺄 수 있습니다

## 남은 것

프론트엔드는 별도 PR로 올립니다. `develop`에 API 테스트 러너(#30)가 들어오면서 `dashboard/page.jsx`의 뷰 분기와 한 줄이 겹쳐 정리가 필요합니다.