### PR TITLE
chore: 쓰지 않는 Neo4j 의존성과 설정 제거

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -9,11 +9,6 @@ DB_URL=jdbc:postgresql://localhost:5432/timiroom
 DB_USERNAME=
 DB_PASSWORD=
 
-# ── Neo4j ─────────────────────────────────────────────────────\
-NEO4J_URI=bolt://localhost:7687
-NEO4J_USERNAME=
-NEO4J_PASSWORD=
-
 # ── Redis ─────────────────────────────────────────────────────\
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/README.md
+++ b/README.md
@@ -75,11 +75,9 @@
 ### 1. 인프라 실행 (Docker)
 
 ```bash
-# 프로젝트 루트에서 실행 — PostgreSQL, Redis, Neo4j, Kafka 전체 기동
+# 프로젝트 루트에서 실행 — PostgreSQL, Redis, Kafka, MinIO 전체 기동
 docker compose up -d
 ```
-
-> **주의:** Neo4j는 초기화에 10~20초 소요됩니다. 백엔드 기동 전 `docker ps`로 `healthy` 상태 확인 후 실행하세요.
 
 ### 2. 환경변수 설정
 
@@ -99,11 +97,6 @@ DB_PASSWORD=timiroom1234
 # Redis
 REDIS_HOST=localhost
 REDIS_PORT=6379
-
-# Neo4j
-NEO4J_URI=bolt://localhost:7687
-NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=timiroom1234
 
 # OAuth2 소셜 로그인 (Google Cloud Console / GitHub OAuth App 에서 발급)
 GOOGLE_CLIENT_ID=your_google_client_id

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,6 @@ dependencies {
 	// pgvector (RAG용 벡터 저장)
 	implementation 'com.pgvector:pgvector:0.1.6'
 
-	// Neo4j (그래프 DB)
-	implementation 'org.springframework.boot:spring-boot-starter-data-neo4j'
-
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.session:spring-session-data-redis'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,19 +20,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # ── Neo4j ───────────────────────────────────────────────────────
-  neo4j:
-    image: neo4j:5
-    container_name: timiroom-neo4j
-    ports:
-      - "7474:7474"
-      - "7687:7687"
-    environment:
-      NEO4J_AUTH: neo4j/timiroom1234
-      TZ: Asia/Seoul
-    volumes:
-      - neo4j_data:/data
-
   # ── Redis ───────────────────────────────────────────────────────
   redis:
     image: redis:7-alpine
@@ -111,7 +98,6 @@ services:
 
 volumes:
   postgres_data:
-  neo4j_data:
   redis_data:
   zookeeper_data:
   zookeeper_log:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -38,12 +38,6 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
-  neo4j:
-    uri: ${NEO4J_URI}
-    authentication:
-      username: ${NEO4J_USERNAME}
-      password: ${NEO4J_PASSWORD}
-
   data:
     redis:
       host: ${REDIS_HOST}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,13 +28,6 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
 
-  # ── Neo4j ────────────────────────────────────────────────────────
-  neo4j:
-    uri: ${NEO4J_URI:bolt://localhost:7687}
-    authentication:
-      username: ${NEO4J_USERNAME:neo4j}
-      password: ${NEO4J_PASSWORD:timiroom1234}
-
   # ── Redis ────────────────────────────────────────────────────────
   data:
     redis:


### PR DESCRIPTION
## 왜

**Java 코드에서 Neo4j를 쓰는 곳이 한 군데도 없습니다.** `@Node`도, Neo4j Repository도, Cypher 질의도 0건입니다.

그런데 `spring-boot-starter-data-neo4j`가 들어 있어 `Neo4jHealthIndicator`가 자동 등록되고, 연결이 되지 않으면 애플리케이션 전체 health가 DOWN이 됩니다. **아무도 쓰지 않는 것이 서비스 상태를 대신 말하고 있었습니다.**

## 지금 운영 상태

```
GET /actuator/health            → 503  {"status":"DOWN"}
GET /actuator/health/readiness  → 200  UP
GET /mock/1/_endpoints          → 200        ← Postgres 정상
```

집계 health가 DOWN인데 아무도 몰랐던 이유는 **probe가 그걸 보지 않기** 때문입니다. `rollout.yaml`의 liveness/readiness probe는 `/actuator/health/liveness`·`/readiness`만 확인하므로 파드도 트래픽도 정상이었습니다.

실제 영향은 없었지만, **"DOWN인데 아무도 안 보는" 상태는 진짜 문제가 생겨도 알아채지 못한다**는 뜻이라 그대로 두기 어렵습니다.

## 지운 것

| 파일 | 내용 |
|---|---|
| `build.gradle` | `spring-boot-starter-data-neo4j` |
| `application.yml` / `application-prod.yml` | `spring.neo4j` 블록 |
| `docker-compose.yml` | `neo4j` 서비스와 `neo4j_data` 볼륨 |
| `.env.local.example`, `README.md` | `NEO4J_*` 안내 |

로컬 기동이 그만큼 빨라집니다. README가 *"Neo4j는 초기화에 10~20초 소요됩니다. 백엔드 기동 전 healthy 상태 확인 후 실행하세요"* 라고 안내하던 그 컨테이너입니다.

## 솔직히 말하면 — 진단은 확정 못 했습니다

Neo4j가 DOWN의 원인인지 **직접 확인하지 못했습니다.** 운영 호스트(QNAP)에 접근할 수단이 없었습니다.

다만 두 가지는 확실합니다.

1. 쓰지 않는 의존성을 지우는 일은 원인과 무관하게 맞습니다
2. **배포하면 그 자체가 진단이 됩니다** — health가 UP이 되면 원인 확정, 그대로면 남은 후보가 db/redis/diskSpace로 좁혀집니다

## 확인

`clean build` 통과. 전체 테스트 **64개 통과**. `TimiroomBackendApplicationTests`(애플리케이션 컨텍스트 로딩)도 정상입니다.

## 따로 봐주셨으면

**① `timiroom-ops` 정리는 이 PR에 넣지 않았습니다.**

배포 레포에 아직 남아 있습니다:
- `infra/external-db.yaml` — `neo4j` Service / Endpoints
- `apps/backend/rollout.yaml` — `NEO4J_URI`, `NEO4J_USERNAME` env
- sealed secret의 `NEO4J_PASSWORD`

이 PR 후에는 **쓰이지 않는 값이라 해롭지는 않지만** 정리 대상입니다. GitOps 레포라 커밋이 곧 배포이므로 별도 PR로 다뤄야 한다고 보았습니다.

**② 발표 자료와 어긋납니다.**

시스템 설계 장표에 *"Neo4j — 기획·API·DB 관계 그래프"* 가 아직 들어가 있습니다. 정작 그 기능(지식 그래프, #41)은 Neo4j 없이 매 요청 계산 방식으로 만들었습니다. **문서를 코드에 맞출지, Neo4j를 실제로 쓸 계획이 있는지** 팀 확인이 필요합니다. 계획이 있다면 이 PR은 보류하는 게 맞습니다.