### PR TITLE
feat: PR 없이 올라온 커밋도 명세와 대조한다

### DIFF
--- a/src/main/java/com/timiroom/domain/github/GithubWebhookService.java
+++ b/src/main/java/com/timiroom/domain/github/GithubWebhookService.java
@@ -26,6 +26,10 @@ public class GithubWebhookService {
 
     @Async
     public void handle(String event, JsonNode payload) {
+        if ("push".equals(event)) {
+            handlePush(payload);
+            return;
+        }
         if (!"pull_request".equals(event)) return;
         String action = payload.path("action").asText();
         boolean review = REVIEW_ACTIONS.contains(action);
@@ -50,6 +54,48 @@ public class GithubWebhookService {
                             }
                         }),
                 () -> log.debug("연결되지 않은 GitHub repo webhook 무시 — githubRepoId={}", githubRepoId));
+    }
+
+    /**
+     * PR을 거치지 않고 브랜치에 바로 올라온 커밋을 검사한다.
+     *
+     * GitHub App은 이미 push를 구독하고 있었지만 처리하는 코드가 없어 그냥 버려지고 있었다.
+     * PR을 열지 않으면 정합성 검사를 통째로 건너뛸 수 있었다는 뜻이다.
+     *
+     * 걸러 내는 것들
+     * - 브랜치 삭제(after가 0으로 채워짐)와 첫 push(before가 0): 비교할 앞이 없다
+     * - 태그·기타 ref: 코드 변경이 아니다
+     * - 봇이 올린 커밋: 배포 파이프라인이 이미지 태그를 올리는 것까지 검사할 이유가 없다
+     */
+    private void handlePush(JsonNode payload) {
+        String ref = payload.path("ref").asText();
+        if (!ref.startsWith("refs/heads/")) return;
+
+        String before = payload.path("before").asText("");
+        String after = payload.path("after").asText("");
+        if (isEmptySha(before) || isEmptySha(after)) return;
+
+        // PR로 들어온 머지 커밋은 이미 PR 경로에서 검사했다. 다시 부를 필요가 없다.
+        if (payload.path("head_commit").path("message").asText("").startsWith("Merge pull request")) return;
+
+        long githubRepoId = payload.path("repository").path("id").asLong(-1);
+        if (githubRepoId < 0) return;
+
+        String message = payload.path("head_commit").path("message").asText("");
+        githubRepoRepository.findByGithubRepoId(githubRepoId).ifPresent(repo ->
+                projectRepoLinkRepository.findByGithubRepoId(repo.getId()).forEach(link -> {
+                    try {
+                        pullRequestConsistencyService.checkPush(link.getProjectId(), repo, before, after, message);
+                    } catch (Exception e) {
+                        log.error("push 정합성 검사 실패 — project={}, repo={}, ref={}: {}",
+                                link.getProjectId(), repo.getFullName(), ref, e.getMessage(), e);
+                    }
+                }));
+    }
+
+    /** 브랜치 생성·삭제 시 GitHub이 0으로 채워 보내는 SHA */
+    private boolean isEmptySha(String sha) {
+        return sha.isBlank() || sha.chars().allMatch(c -> c == '0');
     }
 
     private void runReview(Long projectId, GithubRepo repo, int pullNumber) {

--- a/src/main/java/com/timiroom/domain/github/PullRequestConsistencyService.java
+++ b/src/main/java/com/timiroom/domain/github/PullRequestConsistencyService.java
@@ -169,6 +169,49 @@ public class PullRequestConsistencyService {
                 true, false, review.htmlUrl(), checkRun.htmlUrl(), analysis.evaluator(), findings);
     }
 
+    /**
+     * PR을 거치지 않고 브랜치에 바로 올라온 커밋을 명세와 대조한다.
+     *
+     * PR 경로가 있는데도 이걸 두는 이유 — PR을 쓰지 않으면 검사를 통째로 건너뛸 수 있어서다.
+     * 우회로가 열려 있는 검사는 검사가 아니다.
+     *
+     * PR과 다른 점 두 가지.
+     * 첫째, 리뷰 코멘트를 남기지 않는다. 달 PR이 없다. 대신 커밋에 Check Run을 올린다.
+     * 둘째, 결과를 review record에 쓰지 않는다. 그 표는 PR 번호로 묶여 있고, push에는
+     * 번호가 없다. 이미 올라간 코드라 "다시 검사하지 않기"를 위한 중복 방지도 필요 없다.
+     *
+     * 막을 수는 없고 알릴 수만 있다. 이미 들어간 코드이기 때문이다. 그래서 경고가 있을 때만
+     * 사람을 부른다.
+     */
+    @Transactional
+    public void checkPush(Long projectId, GithubRepo repo, String beforeSha, String afterSha, String headCommitMessage) {
+        List<GithubPullRequestFileInfo> files =
+                githubClient.compareCommits(repo.getFullName(), repo.getInstallationId(), beforeSha, afterSha);
+        if (files.isEmpty()) {
+            log.debug("push에 변경 파일이 없어 정합성 검사 생략 — repo={}, {}..{}",
+                    repo.getFullName(), shortSha(beforeSha), shortSha(afterSha));
+            return;
+        }
+
+        Map<PipelineArtifact.ArtifactType, String> specifications = latestSpecifications(projectId);
+        AnalysisOutcome analysis = analyzeWithAgent(repo,
+                new ChangeContext(0, headCommitMessage, "", "직접 push", ""), files, specifications);
+
+        List<ConsistencyFinding> findings = analysis.findings();
+        long warnings = findings.stream().filter(f -> "WARNING".equals(f.severity())).count();
+        long inconclusive = findings.stream().filter(f -> "INCONCLUSIVE".equals(f.severity())).count();
+        int score = inconclusive > 0 ? 0 : Math.max(0, 100 - (int) warnings * 25);
+
+        githubClient.createCompletedConsistencyCheckRun(repo.getFullName(), repo.getInstallationId(),
+                afterSha, score, inconclusive > 0, pushCheckMarkdown(score, findings, analysis));
+
+        if (warnings + inconclusive > 0) {
+            notifyPushMembers(projectId, repo, afterSha, warnings, inconclusive);
+        }
+        log.info("push 정합성 검사 — project={}, repo={}, sha={}, 점수={}, 경고={}",
+                projectId, repo.getFullName(), shortSha(afterSha), score, warnings);
+    }
+
     /** 프로젝트 전체에서 가장 최근에 검사된 PR의 정합성 요약. 아직 검사한 PR이 없으면 null. */
     @Transactional(readOnly = true)
     public ProjectConsistencySummary getLatestSummary(Long projectId, Long memberId) {
@@ -203,6 +246,50 @@ public class PullRequestConsistencyService {
         } catch (Exception e) {
             return List.of();
         }
+    }
+
+    /**
+     * push용 Check Run 본문.
+     *
+     * PR 리뷰 본문과 달리 "병합 전에 확인하세요"라고 쓰지 않는다. 이미 들어간 코드라
+     * 막을 수 있는 시점이 지났고, 할 수 있는 말은 "명세와 어긋나니 둘 중 하나를 고치라"는 것뿐이다.
+     */
+    private String pushCheckMarkdown(int score, List<ConsistencyFinding> findings, AnalysisOutcome analysis) {
+        List<ConsistencyFinding> warnings = findings.stream()
+                .filter(finding -> "WARNING".equals(finding.severity())).toList();
+
+        StringBuilder body = new StringBuilder("## 🔍 timiroom 정합성 검사 (직접 push)\n\n")
+                .append(warnings.isEmpty() ? "> [!NOTE]\n> " : "> [!WARNING]\n> ")
+                .append(warnings.isEmpty()
+                        ? "이 커밋과 명세 사이에서 어긋난 점을 찾지 못했습니다."
+                        : "이 커밋이 명세와 어긋나는 점이 **" + warnings.size() + "건** 있습니다. "
+                          + "이미 반영된 코드이므로, 구현을 되돌리거나 명세를 갱신해야 합니다.")
+                .append("\n\n")
+                .append("| 항목 | 결과 |\n| --- | --- |\n")
+                .append("| 정합성 점수 | **").append(score).append("/100** |\n")
+                .append("| 리뷰 엔진 | ").append(evaluatorLabel(analysis.evaluator())).append(" |\n")
+                .append("| 비교 범위 | 최신 API·DB 명세 ↔ push된 변경 |\n\n")
+                .append("### 요약\n\n> ").append(markdownText(analysis.summary())).append("\n\n");
+
+        if (!warnings.isEmpty()) {
+            body.append("### ⚠️ 확인 사항\n\n");
+            warnings.forEach(finding -> appendFindingDetails(body, finding, true));
+        }
+
+        body.append("---\n<sub>PR을 거치지 않고 브랜치에 직접 올라온 커밋이라 리뷰 코멘트 대신 "
+                + "검사 결과만 남깁니다.</sub>");
+        return body.toString();
+    }
+
+    private void notifyPushMembers(Long projectId, GithubRepo repo, String sha,
+                                   long warningCount, long inconclusiveCount) {
+        String detail = warningCount > 0 ? warningCount + "개의 명세 정합성 경고"
+                : "근거 부족으로 인한 판정 보류 " + inconclusiveCount + "건";
+        String content = repo.getFullName() + " " + shortSha(sha)
+                + " (PR 없이 직접 push)에서 " + detail + "이 발견됐습니다.";
+        projectMemberRepository.findByProjectId(projectId).forEach(member -> notificationService.create(
+                member.getMemberId(), NotificationType.PR_CONSISTENCY_REVIEW, "직접 push 정합성 확인 필요",
+                content, NotificationReferenceType.PULL_REQUEST, 0L));
     }
 
     private void notifyProjectMembers(Long projectId, GithubRepo repo, int pullNumber,
@@ -245,13 +332,28 @@ public class PullRequestConsistencyService {
                                              GithubPullRequestInfo pullRequest,
                                              List<GithubPullRequestFileInfo> files,
                                              Map<PipelineArtifact.ArtifactType, String> specifications) {
+        return analyzeWithAgent(repo, new ChangeContext(
+                pullRequest.number(), pullRequest.title(), pullRequest.body(),
+                pullRequest.headRef(), pullRequest.baseRef()), files, specifications);
+    }
+
+    /**
+     * 변경 한 덩어리를 명세와 대조한다.
+     *
+     * PR 객체 대신 ChangeContext를 받는다. 검사에 필요한 건 "무엇이 왜 바뀌었는가"뿐이고
+     * 그건 PR에만 있는 정보가 아니다. push도 같은 판단을 받아야 하는데 PR 번호가 없다.
+     */
+    private AnalysisOutcome analyzeWithAgent(GithubRepo repo,
+                                             ChangeContext change,
+                                             List<GithubPullRequestFileInfo> files,
+                                             Map<PipelineArtifact.ArtifactType, String> specifications) {
         if (!agentEnabled) {
             List<ConsistencyFinding> findings = analyzeWithRules(files, specifications);
             return new AnalysisOutcome(findings, "RULES", defaultReviewSummary(findings));
         }
         try {
             String runtime = normalizedAgentRuntime();
-            Object request = agentRequest(repo, pullRequest, files, specifications);
+            Object request = agentRequest(repo, change, files, specifications);
             JsonNode response = "PYTHON".equals(runtime)
                     ? consistencyServiceClient.reviewPullRequestConsistency(request)
                     : ragPipelineClient.reviewPullRequestConsistency(request);
@@ -308,17 +410,17 @@ public class PullRequestConsistencyService {
     }
 
     private Map<String, Object> agentRequest(GithubRepo repo,
-                                             GithubPullRequestInfo pullRequest,
+                                             ChangeContext change,
                                              List<GithubPullRequestFileInfo> files,
                                              Map<PipelineArtifact.ArtifactType, String> specifications) {
         Map<String, Object> request = new LinkedHashMap<>();
         request.put("model", agentModel);
         request.put("repository", repo.getFullName());
-        request.put("pullNumber", pullRequest.number());
-        request.put("title", pullRequest.title());
-        request.put("body", pullRequest.body());
-        request.put("headRef", pullRequest.headRef());
-        request.put("baseRef", pullRequest.baseRef());
+        request.put("pullNumber", change.pullNumber());
+        request.put("title", change.title());
+        request.put("body", change.body());
+        request.put("headRef", change.headRef());
+        request.put("baseRef", change.baseRef());
         request.put("apiSpec", specifications.get(PipelineArtifact.ArtifactType.API_SPEC));
         request.put("dbSchema", specifications.get(PipelineArtifact.ArtifactType.DB_SCHEMA));
         request.put("changedFiles", files.stream().map(file -> {
@@ -666,6 +768,13 @@ public class PullRequestConsistencyService {
     }
 
     private record AnalysisOutcome(List<ConsistencyFinding> findings, String evaluator, String summary) {}
+
+    /**
+     * 검사에 필요한 변경의 맥락. PR이면 번호와 제목이, push면 브랜치와 커밋 메시지가 들어온다.
+     * pullNumber는 push일 때 0이다 — 붙일 PR이 없다는 뜻이다.
+     */
+    private record ChangeContext(int pullNumber, String title, String body,
+                                 String headRef, String baseRef) {}
 
     private String normalizedAgentRuntime() {
         String normalized = agentRuntime == null ? "" : agentRuntime.trim().toUpperCase();

--- a/src/main/java/com/timiroom/infra/github/GithubClient.java
+++ b/src/main/java/com/timiroom/infra/github/GithubClient.java
@@ -201,6 +201,29 @@ public class GithubClient {
     }
 
     /**
+     * 두 커밋 사이에 바뀐 파일(최대 100건).
+     *
+     * PR은 "base 대비 무엇이 달라졌는가"가 GitHub 쪽에 이미 정리되어 있지만,
+     * push에는 그런 것이 없어 before와 after 사이를 직접 물어야 한다.
+     * 응답 모양은 PR 변경 파일과 같아 정합성 검사가 그대로 받아 쓸 수 있다.
+     */
+    public List<GithubPullRequestFileInfo> compareCommits(String repositoryFullName, long installationId,
+                                                          String base, String head) {
+        JsonNode body = get(repositoryPath(repositoryFullName) + "/compare/" + base + "..." + head,
+                authService.getInstallationToken(installationId));
+        List<GithubPullRequestFileInfo> result = new ArrayList<>();
+        for (JsonNode node : body.path("files")) {
+            result.add(new GithubPullRequestFileInfo(
+                    node.path("filename").asText(),
+                    node.path("status").asText(),
+                    node.path("additions").asInt(0),
+                    node.path("deletions").asInt(0),
+                    node.path("patch").asText("")));
+        }
+        return result;
+    }
+
+    /**
      * 특정 ref의 UTF-8 소스 파일 원문을 읽는다. GitHub Contents API의 base64 응답만 허용하고,
      * 너무 큰 파일·디렉터리·바이너리·없는 파일은 정합성 입력에서 안전하게 제외한다.
      */

--- a/src/test/java/com/timiroom/domain/github/GithubWebhookServiceTest.java
+++ b/src/test/java/com/timiroom/domain/github/GithubWebhookServiceTest.java
@@ -1,0 +1,150 @@
+package com.timiroom.domain.github;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+/**
+ * push 웹훅 처리 검증.
+ *
+ * 이 기능의 값어치는 "검사를 돌린다"보다 "돌리지 말아야 할 때 돌리지 않는다"에 있다.
+ * GitHub은 브랜치 생성·삭제·태그까지 전부 push로 보내오고, 배포 파이프라인이
+ * 만들어 내는 커밋도 섞여 든다. 아무거나 다 검사하면 GitHub 호출 한도를 먹고
+ * 알림만 시끄러워진다. 그래서 걸러 내는 쪽을 중심으로 확인한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class GithubWebhookServiceTest {
+
+    @Mock GithubRepoRepository githubRepoRepository;
+    @Mock ProjectRepoLinkRepository projectRepoLinkRepository;
+    @Mock GithubPullRequestReviewRecordRepository reviewRecordRepository;
+    @Mock PullRequestConsistencyService pullRequestConsistencyService;
+
+    @InjectMocks GithubWebhookService service;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static final long GITHUB_REPO_ID = 987654L;
+    private static final String BEFORE = "1111111111111111111111111111111111111111";
+    private static final String AFTER  = "2222222222222222222222222222222222222222";
+    private static final String EMPTY  = "0000000000000000000000000000000000000000";
+
+    @BeforeEach
+    void setUp() {
+        GithubRepo repo = GithubRepo.builder()
+                .githubRepoId(GITHUB_REPO_ID)
+                .fullName("timiroom/timiroom-backend")
+                .installationId(146037712L)
+                .build();
+        given(githubRepoRepository.findByGithubRepoId(GITHUB_REPO_ID)).willReturn(Optional.of(repo));
+        given(projectRepoLinkRepository.findByGithubRepoId(any())).willReturn(List.of(
+                ProjectRepoLink.builder().projectId(1L).githubRepoId(repo.getId()).build()));
+    }
+
+    private JsonNode push(String ref, String before, String after, String message) {
+        try {
+            return mapper.readTree("""
+                    {
+                      "ref": "%s",
+                      "before": "%s",
+                      "after": "%s",
+                      "repository": { "id": %d },
+                      "head_commit": { "message": "%s" }
+                    }
+                    """.formatted(ref, before, after, GITHUB_REPO_ID, message));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("브랜치에 바로 올라온 커밋은 명세와 대조한다")
+    void 직접_push를_검사한다() {
+        service.handle("push", push("refs/heads/develop", BEFORE, AFTER, "fix: 응답 필드 추가"));
+
+        then(pullRequestConsistencyService).should(times(1))
+                .checkPush(eq(1L), any(), eq(BEFORE), eq(AFTER), eq("fix: 응답 필드 추가"));
+    }
+
+    @Test
+    @DisplayName("PR 머지 커밋은 다시 검사하지 않는다")
+    void 머지_커밋은_건너뛴다() {
+        // PR 경로에서 이미 검사했다. 같은 변경을 두 번 검사하면 알림도 두 번 간다.
+        service.handle("push", push("refs/heads/develop", BEFORE, AFTER,
+                "Merge pull request #41 from timiroom/feat/knowledge-graph"));
+
+        then(pullRequestConsistencyService).should(never())
+                .checkPush(anyLong(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("브랜치를 처음 만들거나 지울 때는 비교할 앞이 없어 건너뛴다")
+    void 빈_SHA는_건너뛴다() {
+        service.handle("push", push("refs/heads/feature/new", EMPTY, AFTER, "첫 커밋"));
+        service.handle("push", push("refs/heads/feature/old", BEFORE, EMPTY, "브랜치 삭제"));
+
+        then(pullRequestConsistencyService).should(never())
+                .checkPush(anyLong(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("태그 push는 코드 변경이 아니므로 건너뛴다")
+    void 태그는_건너뛴다() {
+        service.handle("push", push("refs/tags/v1.2.0", BEFORE, AFTER, "release"));
+
+        then(pullRequestConsistencyService).should(never())
+                .checkPush(anyLong(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("연결되지 않은 레포의 push는 무시한다")
+    void 연결되지_않은_레포는_무시한다() {
+        given(githubRepoRepository.findByGithubRepoId(GITHUB_REPO_ID)).willReturn(Optional.empty());
+
+        service.handle("push", push("refs/heads/develop", BEFORE, AFTER, "fix: 무언가"));
+
+        then(pullRequestConsistencyService).should(never())
+                .checkPush(anyLong(), any(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("검사 중 예외가 나도 웹훅 처리는 멈추지 않는다")
+    void 실패해도_예외를_밖으로_던지지_않는다() {
+        // GitHub은 2xx를 받아야 재시도 폭주를 피한다. 실패는 로그로만 남겨야 한다.
+        org.mockito.BDDMockito.willThrow(new IllegalStateException("GitHub 호출 실패"))
+                .given(pullRequestConsistencyService)
+                .checkPush(anyLong(), any(), anyString(), anyString(), anyString());
+
+        service.handle("push", push("refs/heads/develop", BEFORE, AFTER, "fix: 무언가"));
+    }
+
+    @Test
+    @DisplayName("push 외의 모르는 이벤트는 그냥 흘려보낸다")
+    void 모르는_이벤트는_무시한다() {
+        service.handle("issues", push("refs/heads/develop", BEFORE, AFTER, "무관"));
+
+        then(pullRequestConsistencyService).should(never())
+                .checkPush(anyLong(), any(), anyString(), anyString(), anyString());
+    }
+}


### PR DESCRIPTION
> ⚠️ **#41 위에 쌓은 PR입니다.** base가 `develop`이 아니라 `feat/knowledge-graph`입니다.
> 같은 파일(`GithubWebhookService`)을 #41이 이미 고쳐서, `develop`에서 따면 충돌합니다.
> **#41이 머지된 뒤 base를 `develop`으로 바꾸면 됩니다.**

## 문제

GitHub App은 이벤트를 **두 개** 구독하고 있습니다.

```
구독 이벤트: pull_request, push
```

그런데 코드는 첫 줄에서 이랬습니다.

```java
if (!"pull_request".equals(event)) return;   // push는 여기서 버려짐
```

**GitHub은 push를 이미 보내고 있는데 우리가 받아서 버리고 있었습니다.** PR을 열지 않고 브랜치에 바로 밀어 넣으면 정합성 검사를 통째로 건너뛸 수 있었다는 뜻입니다. 우회로가 열려 있는 검사는 검사가 아닙니다.

`develop`에 브랜치 보호가 없어 실제로 가능한 경로입니다.

## PR 경로와 다른 점

| | PR | push |
|---|---|---|
| 리뷰 코멘트 | 남김 | **안 남김** — 달 PR이 없음 |
| Check Run | 올림 | 올림 (커밋 SHA에) |
| review record | 저장 | **저장 안 함** — 표가 PR 번호로 묶여 있음 |
| 중복 방지 | head SHA로 | 불필요 — 이미 올라간 코드 |

**막을 수는 없고 알릴 수만 있습니다.** 이미 들어간 코드이기 때문입니다. Check Run 본문도 *"병합 전에 확인하세요"* 가 아니라 *"구현을 되돌리거나 명세를 갱신하라"* 고 씁니다.

## 걸러 내는 것들

이 기능의 값어치는 "검사를 돌린다"보다 **"돌리지 말아야 할 때 돌리지 않는다"** 에 있습니다. GitHub은 브랜치 생성·삭제·태그까지 전부 push로 보내오고, 배포 파이프라인이 만드는 커밋도 섞여 듭니다. 아무거나 다 검사하면 호출 한도를 먹고 알림만 시끄러워집니다.

- **브랜치 생성**(`before`가 0) / **삭제**(`after`가 0) — 비교할 앞이 없음
- **`refs/heads` 밖의 ref** — 태그 등, 코드 변경이 아님
- **PR 머지 커밋** — PR 경로에서 이미 검사함. 두 번 검사하면 알림도 두 번

## 구조 변경

분석기가 PR 객체 대신 `ChangeContext`를 받도록 바꿨습니다. 검사에 필요한 건 *"무엇이 왜 바뀌었는가"* 이고 그건 PR에만 있는 정보가 아닙니다. PR이면 번호와 제목이, push면 브랜치와 커밋 메시지가 들어갑니다.

`GithubClient.compareCommits()` 추가 — PR은 base 대비 diff가 GitHub 쪽에 정리되어 있지만 push에는 없어 `before...after`를 직접 물어야 합니다. 응답 모양을 PR 변경 파일과 같게 맞춰 검사가 그대로 받아 씁니다.

## 테스트

**7개 추가**, 전체 **95개 통과**. 걸러 내는 조건 위주로 확인했고, 검사 중 예외가 나도 웹훅 처리가 멈추지 않는 것(GitHub이 2xx를 받아야 재시도 폭주를 피함)도 포함했습니다.

## 봐주셨으면

**이게 정말 필요한지부터 봐주세요.**

`develop`에 **브랜치 보호를 걸면 직접 push 자체가 불가능해집니다.** 그러면 이 PR은 일어나지 않을 일을 감시하는 코드가 됩니다. 근본 해결은 레포 설정 쪽에 있고, 이건 그 설정이 없는 동안의 그물입니다.

보호를 걸 계획이라면 **이 PR은 닫는 편이 낫습니다.** 판단 부탁드립니다.