### PR TITLE
ci: CI에서 테스트를 실제로 돌린다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,18 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build
-        run: ./gradlew build -x test --no-daemon
+        # -x test 를 떼어 테스트까지 돌린다. 붙어 있던 동안 "Build pass"는
+        # 컴파일이 됐다는 뜻일 뿐이었고, 테스트가 깨진 채로도 초록불이었다.
+        run: ./gradlew build --no-daemon
+
+      # 실패했을 때 어느 테스트가 왜 깨졌는지 로그만 보고 알기 어렵다.
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-test-report
+          path: build/reports/tests/test
+          retention-days: 7
 
   rag-pipeline:
     name: Rag-Pipeline Build
@@ -71,4 +82,12 @@ jobs:
 
       - name: Build
         working-directory: rag-pipeline
-        run: ./gradlew build -x test --no-daemon
+        run: ./gradlew build --no-daemon
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rag-pipeline-test-report
+          path: rag-pipeline/build/reports/tests/test
+          retention-days: 7

--- a/rag-pipeline/src/test/java/com/rag/pipeline/RagPipelineApplicationTests.java
+++ b/rag-pipeline/src/test/java/com/rag/pipeline/RagPipelineApplicationTests.java
@@ -2,8 +2,20 @@ package com.rag.pipeline;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
+/**
+ * 애플리케이션 컨텍스트가 뜨는지만 확인한다.
+ *
+ * FOUNDRY_API_KEY는 application.yml에 기본값이 없다. 일부러 그렇게 두었다 —
+ * 키 없이 뜬 서버는 첫 요청에서야 실패하므로, 없으면 부팅 단계에서 바로 알아야 한다.
+ * 대신 그 값이 없는 환경(CI)에서는 이 테스트가 자리표시자를 못 채워 깨진다.
+ * 그래서 여기서만 가짜 값을 넣는다. 컨텍스트 로딩에는 값의 내용이 쓰이지 않는다.
+ */
 @SpringBootTest
+@TestPropertySource(properties = {
+    "FOUNDRY_API_KEY=test-key-not-used",
+})
 class RagPipelineApplicationTests {
 
     @Test


### PR DESCRIPTION
## 문제

```yaml
run: ./gradlew build -x test --no-daemon
```

**`-x test` 때문에 CI가 테스트를 건너뛰고 있었습니다.** "Backend Build pass"는 *컴파일이 됐다*는 뜻일 뿐이고, 테스트가 깨진 채로도 초록불이 뜹니다.

`develop`에 브랜치 보호가 없어 리뷰 없이 머지할 수 있는 상태입니다. **CI마저 검증하지 않으면 깨진 코드를 막을 것이 아무것도 남지 않습니다.**

## 왜 붙어 있었는지 확인했습니다

떼기 전에 짐작되는 이유를 하나씩 검증했고, 전부 해당 없었습니다.

| 의심 | 확인 결과 |
|---|---|
| 외부 DB가 필요 | ❌ 컨텍스트 테스트가 **H2 인메모리**로 재정의 |
| Kafka가 필요 | ❌ `@KafkaListener` 0건. 없는 주소(`localhost:19092`)를 줘도 컨텍스트 로딩 성공 |
| Redis가 필요 | ❌ 띄우지 않은 상태에서 전체 통과 |
| Flyway 마이그레이션 | ❌ `V*__*.sql` 0건 |
| **rag-pipeline** | ❌ Postgres 없이 통과 (컨텍스트 로딩 50초, 3개 모두 실제 실행 확인) |

가장 의심했던 건 rag-pipeline이었습니다. `RagPipelineApplicationTests`가 속성 재정의도 테스트 리소스도 없는 맨 `@SpringBootTest`라 DB와 AI 키를 요구할 줄 알았는데, 실제로는 Postgres 하나 없는 상태에서 통과했습니다. AI 빈이 키 없이도 생성되고 DB 연결이 지연 방식이라 컨텍스트 로딩을 막지 않습니다.

**빠른 빌드를 위해 붙였다가 남은 것으로 보입니다.**

## 함께 넣은 것

실패했을 때 어느 테스트가 왜 깨졌는지 로그만으로는 알기 어려워 **테스트 리포트를 아티팩트로 올립니다.** `if: failure()` 조건이라 평소 실행 시간은 그대로입니다.

## 비용

```
지금:        30~60초  (컴파일만)
이 PR 이후:  +50초 정도
```

PR당 1분 남짓 늘어납니다. 그 대가로 테스트가 매 PR마다 실제로 검증됩니다.

## 이 PR이 스스로를 증명합니다

같은 레포 PR은 **PR 브랜치의 워크플로**로 돌기 때문에, 이 PR의 CI 결과가 곧 "테스트를 CI에서 돌릴 수 있는가"에 대한 답입니다. 초록불이면 검증된 것이고, 실패하면 그 로그를 보고 판단하면 됩니다. **머지 전이라 아무것도 깨지지 않습니다.**

## 덧붙여

제가 로컬에서 확인한 건 제 컴퓨터 환경입니다. CI 러너는 완전히 비어 있어 재현하지 못한 변수가 남아 있을 수 있습니다. 그래서 위 표를 근거로만 주장하지 않고, 이 PR의 CI 결과를 함께 봐 주시면 좋겠습니다.